### PR TITLE
[FEAT] KakaoMap 지도 컴포넌트 구현 및 데모앱 추가

### DIFF
--- a/Plugins/DependencyPackagePlugin/ProjectDescriptionHelpers/DependencyPackage/Extension+TargetDependencySPM.swift
+++ b/Plugins/DependencyPackagePlugin/ProjectDescriptionHelpers/DependencyPackage/Extension+TargetDependencySPM.swift
@@ -11,4 +11,5 @@ public extension TargetDependency.SPM {
   static let asyncMoya = TargetDependency.external(name: "AsyncMoya", condition: .none)
   static let composableArchitecture = TargetDependency.external(name: "ComposableArchitecture", condition: .none)
   static let sharing = TargetDependency.external(name: "Sharing", condition: .none)
+  static let kakaoMapsSDK = TargetDependency.external(name: "KakaoMapsSDK-SPM", condition: .none)
 }

--- a/Plugins/ProjectTemplatePlugin/ProjectDescriptionHelpers/infoPlist/InfoPlistDictionary.swift
+++ b/Plugins/ProjectTemplatePlugin/ProjectDescriptionHelpers/infoPlist/InfoPlistDictionary.swift
@@ -185,4 +185,8 @@ extension InfoPlistDictionary {
   func setBaseURL(_ value: String) -> InfoPlistDictionary {
     return self.merging(["BASE_URL": .string(value)]) { (_, new) in new }
   }
+
+  func setKakaoAppKey(_ value: String) -> InfoPlistDictionary {
+    return self.merging(["KAKAO_APP_KEY": .string(value)]) { (_, new) in new }
+  }
 }

--- a/Plugins/ProjectTemplatePlugin/ProjectDescriptionHelpers/infoPlist/Project+InfoPlist.swift
+++ b/Plugins/ProjectTemplatePlugin/ProjectDescriptionHelpers/infoPlist/Project+InfoPlist.swift
@@ -38,6 +38,7 @@ public extension InfoPlist {
           ]
         ]
       ])
+      .setKakaoAppKey("$(KAKAO_APP_KEY)")
   )
 
   static let moduleInfoPlist: Self = .extendingDefault(

--- a/Projects/App/Bangawo.xcodeproj/project.pbxproj
+++ b/Projects/App/Bangawo.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		04389A0F83DC48C2FEABA489 /* DomainInterface.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A43A50B926F67FDB8C7C5129 /* DomainInterface.framework */; };
 		04750C62C373309F6F54D0B9 /* Presentation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6A29A92C803BBEF9ADA9031E /* Presentation.framework */; };
 		0516E7F2B5AC0D954DD32CBD /* TuistFonts+Bangawo.swift in Sources */ = {isa = PBXBuildFile; fileRef = E90D94B9DF7D50C09B671878 /* TuistFonts+Bangawo.swift */; };
+		051779C50D4E16D15CD211E8 /* KakaoMapsSDK.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 1C47D6B037AF1138DB3F3E1C /* KakaoMapsSDK.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		05FA2FE5A60CFD9AE7982AEB /* DataInterface.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E721C7E63953BD446653BC40 /* DataInterface.framework */; };
 		06198A41D1D014E4190A50A1 /* UIKitNavigation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8086E61AF74B835D5FA227D0 /* UIKitNavigation.framework */; };
 		08369DC313F88F0C31DE7DB4 /* UseCase.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0E592FC14590BBF0BD7DE23F /* UseCase.framework */; };
@@ -38,11 +39,14 @@
 		204AA018B46F9585AA597506 /* SwiftUINavigation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BF82197E4E96649EA5CAA793 /* SwiftUINavigation.framework */; };
 		229EA55D3FA3F3A1ECDC19BF /* PerceptionCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F30F7606920BA74459A75455 /* PerceptionCore.framework */; };
 		235741E828C214531D64E82D /* CombineSchedulers.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A9A24308E710594FCEBDD00E /* CombineSchedulers.framework */; };
+		282E37C7B035C91E583EDCBC /* KakaoMapsSDK.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 1C47D6B037AF1138DB3F3E1C /* KakaoMapsSDK.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		2878EDBC845FA902EAB27C58 /* Foundations.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD7E38252D22390F2ED82261 /* Foundations.framework */; };
+		2954B149D7A5E3770D0E9EA8 /* KakaoMapsSDK.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 1C47D6B037AF1138DB3F3E1C /* KakaoMapsSDK.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		297E41EFDF352837C7052548 /* TuistFonts+BangawoDebug.swift in Sources */ = {isa = PBXBuildFile; fileRef = F639C35D3279EE67C97EA819 /* TuistFonts+BangawoDebug.swift */; };
 		29BDC2F3FB06D8806B0E2DC6 /* CasePathsCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3B7CFA342D1C3F014E295A58 /* CasePathsCore.framework */; };
 		29FAA9B0DB7B68A10B6CBD5E /* Foundations.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD7E38252D22390F2ED82261 /* Foundations.framework */; };
 		2AF1F7DB10A8E0306E293747 /* UIKitNavigation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8086E61AF74B835D5FA227D0 /* UIKitNavigation.framework */; };
+		2B1FF2790B3B04C6D02A9C4A /* KakaoMapsSDK-SPM_KakaoMapsSDK_SPM.bundle in Dependencies */ = {isa = PBXBuildFile; fileRef = 6F97AC2A95EA7F5D48A94154 /* KakaoMapsSDK-SPM_KakaoMapsSDK_SPM.bundle */; };
 		30BB0511432CF508D339D2CA /* Model.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3331E5903CD8A0A81A33338B /* Model.framework */; };
 		320710F9420D535135691138 /* CasePathsCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3B7CFA342D1C3F014E295A58 /* CasePathsCore.framework */; };
 		3446857417CDAEF5AB6B2881 /* InternalCollectionsUtilities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 04D0952423F76DEF78CB1221 /* InternalCollectionsUtilities.framework */; };
@@ -89,6 +93,7 @@
 		6F348171114C47DE013127DC /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DD80591ED0247EBC978EA90 /* ContentView.swift */; };
 		70E46907A072250A55DCC648 /* Shared.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 77F76D9E4C3C165627C6A49A /* Shared.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		7239F0D2A640353BDFB77ECE /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 8D64641A673A5184FE8C077F /* Preview Assets.xcassets */; };
+		72AB04AD89E5500C3EF59862 /* KakaoMapsSDK-SPM_KakaoMapsSDK_SPM.bundle in Dependencies */ = {isa = PBXBuildFile; fileRef = 6F97AC2A95EA7F5D48A94154 /* KakaoMapsSDK-SPM_KakaoMapsSDK_SPM.bundle */; };
 		7556A391716AB140FB37FB78 /* Repository.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9CB4E6CAC006993A7B6D68BD /* Repository.framework */; };
 		762AD4FCD6F1D69EEDDAD845 /* IdentifiedCollections.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0A1BE0AC3C1D3386F7B88EDD /* IdentifiedCollections.framework */; };
 		76A319921C9C80839D9BA0BA /* DomainInterface.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A43A50B926F67FDB8C7C5129 /* DomainInterface.framework */; };
@@ -111,6 +116,7 @@
 		8B4B603F58D502BBB5C807BB /* OrderedCollections.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5A5421ED7E526F38520B52A2 /* OrderedCollections.framework */; };
 		8B6C2A21D6860B2D55CB5954 /* SwiftNavigation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 74A2A874D180EE9162DA134D /* SwiftNavigation.framework */; };
 		8C23F7D439A8D7AFB5583207 /* DomainInterface.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = A43A50B926F67FDB8C7C5129 /* DomainInterface.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		8D5EE2B221EFBCE710D32FF5 /* KakaoMapsSDK-SPM_KakaoMapsSDK_SPM.bundle in Dependencies */ = {isa = PBXBuildFile; fileRef = 6F97AC2A95EA7F5D48A94154 /* KakaoMapsSDK-SPM_KakaoMapsSDK_SPM.bundle */; };
 		8FC291C6C74067305745C43D /* CustomDump.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 30CA292DDC8CED1B87D35618 /* CustomDump.framework */; };
 		90765B81F6F1F0AC22F9E0A5 /* Networking.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A9605D64008DC1C1CEFEBAF7 /* Networking.framework */; };
 		9403EC7B879BA24153C5BE55 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DC756959D9071B3202660C14 /* Assets.xcassets */; };
@@ -165,6 +171,7 @@
 		D1F92D6249D0C1AC21D53BC5 /* CombineSchedulers.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A9A24308E710594FCEBDD00E /* CombineSchedulers.framework */; };
 		D21BF8520188687B3D137658 /* ConcurrencyExtras.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 32DBED5A352636241E054A3C /* ConcurrencyExtras.framework */; };
 		D2846751686A461F4AEFB438 /* CasePaths.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D7A4EEFD0734C378EBB23A97 /* CasePaths.framework */; };
+		D2A80743E31C78CF241CA1F3 /* KakaoMapsSDK-SPM_KakaoMapsSDK_SPM.bundle in Dependencies */ = {isa = PBXBuildFile; fileRef = 6F97AC2A95EA7F5D48A94154 /* KakaoMapsSDK-SPM_KakaoMapsSDK_SPM.bundle */; };
 		D3145843B57E9BF9FD52A10C /* UIKitNavigation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8086E61AF74B835D5FA227D0 /* UIKitNavigation.framework */; };
 		D46852FFFCFE97FD18734834 /* Networking.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A9605D64008DC1C1CEFEBAF7 /* Networking.framework */; };
 		D4AB0432FB440F54CF8BDE50 /* XCTestDynamicOverlay.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 462D5371FE44F94162F3B51A /* XCTestDynamicOverlay.framework */; };
@@ -172,9 +179,11 @@
 		DA07250E94073133B4F0CF91 /* Perception.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A76F5409027F278B0373D4F1 /* Perception.framework */; };
 		DD1FD511D829EBF9B2EE6A6A /* Repository.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9CB4E6CAC006993A7B6D68BD /* Repository.framework */; };
 		DE93E4361B461FE6E2E633D4 /* BangawoApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3657EEDDB069BC04C1808E /* BangawoApp.swift */; };
+		E0D2A51AF4180CBA9EB43499 /* KakaoMapsSDK.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 1C47D6B037AF1138DB3F3E1C /* KakaoMapsSDK.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		E0FB586985B22920A044557A /* Presentation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6A29A92C803BBEF9ADA9031E /* Presentation.framework */; };
 		E11143019690CE4A8FEA0562 /* DomainInterface.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = A43A50B926F67FDB8C7C5129 /* DomainInterface.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		E129FAC9665AB83DDF927589 /* Shared.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 77F76D9E4C3C165627C6A49A /* Shared.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		E147BC1489860CCA796D0FB3 /* KakaoMapsSDK-SPM_KakaoMapsSDK_SPM.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 6F97AC2A95EA7F5D48A94154 /* KakaoMapsSDK-SPM_KakaoMapsSDK_SPM.bundle */; };
 		E24FDCF5890F32DE9648BBB3 /* Clocks.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 45234DE6FD907DA09A3F8F85 /* Clocks.framework */; };
 		E2661F036690D60CBA9D2C9E /* Dependencies.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 29D819438A47979054BC6DAC /* Dependencies.framework */; };
 		E37D7A237F0CB42372C83DA9 /* Model.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3331E5903CD8A0A81A33338B /* Model.framework */; };
@@ -186,11 +195,14 @@
 		E790A97A1C40DDFA75A27CA4 /* Entity.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EB021004904FC0BC0693A965 /* Entity.framework */; };
 		E8C8237C6E3B1006122C5ECD /* BangawoApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3657EEDDB069BC04C1808E /* BangawoApp.swift */; };
 		E991BF0CBE11534FF4AF918A /* Clocks.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 45234DE6FD907DA09A3F8F85 /* Clocks.framework */; };
+		EB2D997442EA50F53028D65C /* KakaoMapsSDK-SPM_KakaoMapsSDK_SPM.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 6F97AC2A95EA7F5D48A94154 /* KakaoMapsSDK-SPM_KakaoMapsSDK_SPM.bundle */; };
 		EBE03B3934CE363D2C4874D4 /* CasePaths.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D7A4EEFD0734C378EBB23A97 /* CasePaths.framework */; };
 		EC7FBC41F7A78198238F7BE3 /* InternalCollectionsUtilities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 04D0952423F76DEF78CB1221 /* InternalCollectionsUtilities.framework */; };
 		EF7D69A751E441EC7EF0D159 /* Sharing1.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BDB34E76BED7EC98708D4FCF /* Sharing1.framework */; };
 		F1312777E98A5E70FFC389E0 /* OrderedCollections.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5A5421ED7E526F38520B52A2 /* OrderedCollections.framework */; };
 		F283DA0F41FA07F2B7624B2C /* TuistBundle+BangawoStage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 499FB6DBB68F5BD821EA259B /* TuistBundle+BangawoStage.swift */; };
+		F34FCA4430A958A07E38257E /* KakaoMapsSDK-SPM_KakaoMapsSDK_SPM.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 6F97AC2A95EA7F5D48A94154 /* KakaoMapsSDK-SPM_KakaoMapsSDK_SPM.bundle */; };
+		F4EF4BD55BCFA79F5218F990 /* KakaoMapsSDK-SPM_KakaoMapsSDK_SPM.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 6F97AC2A95EA7F5D48A94154 /* KakaoMapsSDK-SPM_KakaoMapsSDK_SPM.bundle */; };
 		F7D142F9E746625EC17BC9A7 /* DomainInterface.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = A43A50B926F67FDB8C7C5129 /* DomainInterface.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		FA8350E9F7FD40F8153016EA /* IdentifiedCollections.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0A1BE0AC3C1D3386F7B88EDD /* IdentifiedCollections.framework */; };
 		FC8BF2333B4C513054F0FBCB /* SwiftNavigation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 74A2A874D180EE9162DA134D /* SwiftNavigation.framework */; };
@@ -218,6 +230,7 @@
 			files = (
 				F7D142F9E746625EC17BC9A7 /* DomainInterface.framework in Embed Frameworks */,
 				E129FAC9665AB83DDF927589 /* Shared.framework in Embed Frameworks */,
+				2954B149D7A5E3770D0E9EA8 /* KakaoMapsSDK.xcframework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -227,6 +240,7 @@
 			buildActionMask = 8;
 			dstSubfolderSpec = 16;
 			files = (
+				2B1FF2790B3B04C6D02A9C4A /* KakaoMapsSDK-SPM_KakaoMapsSDK_SPM.bundle in Dependencies */,
 				988FCB25F666ECB90D49E0C1 /* swift-composable-architecture_ComposableArchitecture.bundle in Dependencies */,
 				3DA33EB35E4C5199DEB19B2D /* swift-sharing_Sharing.bundle in Dependencies */,
 			);
@@ -238,6 +252,7 @@
 			buildActionMask = 8;
 			dstSubfolderSpec = 16;
 			files = (
+				8D5EE2B221EFBCE710D32FF5 /* KakaoMapsSDK-SPM_KakaoMapsSDK_SPM.bundle in Dependencies */,
 				5AA56FA1E6668190C5B79539 /* swift-composable-architecture_ComposableArchitecture.bundle in Dependencies */,
 				AB790034B34E93EFDDC8EB68 /* swift-sharing_Sharing.bundle in Dependencies */,
 			);
@@ -252,6 +267,7 @@
 			files = (
 				AE9372ADFADBA23747AF172A /* DomainInterface.framework in Embed Frameworks */,
 				C50BB1D5307BD08E55B2A04C /* Shared.framework in Embed Frameworks */,
+				051779C50D4E16D15CD211E8 /* KakaoMapsSDK.xcframework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -261,6 +277,7 @@
 			buildActionMask = 8;
 			dstSubfolderSpec = 16;
 			files = (
+				72AB04AD89E5500C3EF59862 /* KakaoMapsSDK-SPM_KakaoMapsSDK_SPM.bundle in Dependencies */,
 				A407BA31EC4FFD54CC645AD9 /* swift-composable-architecture_ComposableArchitecture.bundle in Dependencies */,
 				E480592A36D81710BA77ED2A /* swift-sharing_Sharing.bundle in Dependencies */,
 			);
@@ -275,6 +292,7 @@
 			files = (
 				E11143019690CE4A8FEA0562 /* DomainInterface.framework in Embed Frameworks */,
 				D88664E2609C8AE30AFF905D /* Shared.framework in Embed Frameworks */,
+				E0D2A51AF4180CBA9EB43499 /* KakaoMapsSDK.xcframework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -284,6 +302,7 @@
 			buildActionMask = 8;
 			dstSubfolderSpec = 16;
 			files = (
+				D2A80743E31C78CF241CA1F3 /* KakaoMapsSDK-SPM_KakaoMapsSDK_SPM.bundle in Dependencies */,
 				49CA630F2C8709B2BE2F262D /* swift-composable-architecture_ComposableArchitecture.bundle in Dependencies */,
 				E47CF28DB08CE038BB6A7852 /* swift-sharing_Sharing.bundle in Dependencies */,
 			);
@@ -308,6 +327,7 @@
 			files = (
 				8C23F7D439A8D7AFB5583207 /* DomainInterface.framework in Embed Frameworks */,
 				70E46907A072250A55DCC648 /* Shared.framework in Embed Frameworks */,
+				282E37C7B035C91E583EDCBC /* KakaoMapsSDK.xcframework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -323,6 +343,7 @@
 		12D2265ACC470FCE57789398 /* TuistAssets+Bangawo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TuistAssets+Bangawo.swift"; sourceTree = "<group>"; };
 		142069E341FFF050460F894C /* Bangawo_Stage.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Bangawo_Stage.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		160A9405DB71EE17FF10726D /* BangawoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BangawoTests.swift; sourceTree = "<group>"; };
+		1C47D6B037AF1138DB3F3E1C /* KakaoMapsSDK.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = KakaoMapsSDK.xcframework; path = "/Users/hyeji/Bangawo/Tuist/.build/checkouts/KakaoMapsSDK-SPM/BinaryFramework/KakaoMapsSDK.xcframework"; sourceTree = "<absolute>"; };
 		1DD80591ED0247EBC978EA90 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		29D819438A47979054BC6DAC /* Dependencies.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Dependencies.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		30CA292DDC8CED1B87D35618 /* CustomDump.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CustomDump.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -339,6 +360,7 @@
 		5FF209F8D80F33684784A9B4 /* IssueReportingPackageSupport.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = IssueReportingPackageSupport.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6A29A92C803BBEF9ADA9031E /* Presentation.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Presentation.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6AC954C5E799CBEE210688F8 /* Bangawo_Debug.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Bangawo_Debug.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		6F97AC2A95EA7F5D48A94154 /* KakaoMapsSDK-SPM_KakaoMapsSDK_SPM.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "KakaoMapsSDK-SPM_KakaoMapsSDK_SPM.bundle"; sourceTree = BUILT_PRODUCTS_DIR; };
 		74A2A874D180EE9162DA134D /* SwiftNavigation.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftNavigation.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7635B2B7D66853E82CB42091 /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
 		77F76D9E4C3C165627C6A49A /* Shared.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Shared.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -614,6 +636,7 @@
 				04D0952423F76DEF78CB1221 /* InternalCollectionsUtilities.framework */,
 				F6108A4E21485A7C7233D227 /* IssueReporting.framework */,
 				5FF209F8D80F33684784A9B4 /* IssueReportingPackageSupport.framework */,
+				6F97AC2A95EA7F5D48A94154 /* KakaoMapsSDK-SPM_KakaoMapsSDK_SPM.bundle */,
 				3331E5903CD8A0A81A33338B /* Model.framework */,
 				A9605D64008DC1C1CEFEBAF7 /* Networking.framework */,
 				5A5421ED7E526F38520B52A2 /* OrderedCollections.framework */,
@@ -694,6 +717,14 @@
 			name = Project;
 			sourceTree = "<group>";
 		};
+		92B104BF077563BD0712A9F9 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				1C47D6B037AF1138DB3F3E1C /* KakaoMapsSDK.xcframework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		A30D0638F16069E0A4DCAE6B /* Sources */ = {
 			isa = PBXGroup;
 			children = (
@@ -716,6 +747,7 @@
 			children = (
 				1EF9A9A700A56B7E70E3A84C /* Products */,
 				8455F93F1111D63D46040682 /* Project */,
+				92B104BF077563BD0712A9F9 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -886,6 +918,7 @@
 				77713C685F68858056E0AF7F /* Assets.xcassets in Resources */,
 				123AA3C78A911457F438CB14 /* PretendardVariable.ttf in Resources */,
 				7C8166407B308E1946C3E2B2 /* Preview Assets.xcassets in Resources */,
+				EB2D997442EA50F53028D65C /* KakaoMapsSDK-SPM_KakaoMapsSDK_SPM.bundle in Resources */,
 				CAD52F480BCD37686D2183F3 /* swift-composable-architecture_ComposableArchitecture.bundle in Resources */,
 				7A627145343A5D092C697507 /* swift-sharing_Sharing.bundle in Resources */,
 			);
@@ -898,6 +931,7 @@
 				5427481A7C5D2CF365BAD048 /* Assets.xcassets in Resources */,
 				A3A1C46EE06C4324574BD1A5 /* PretendardVariable.ttf in Resources */,
 				FFBFFF23F18FDC03C1634049 /* Preview Assets.xcassets in Resources */,
+				F34FCA4430A958A07E38257E /* KakaoMapsSDK-SPM_KakaoMapsSDK_SPM.bundle in Resources */,
 				54C5FEA02ACBDA6CBD9549BC /* swift-composable-architecture_ComposableArchitecture.bundle in Resources */,
 				CC832358653A4AC536B83B29 /* swift-sharing_Sharing.bundle in Resources */,
 			);
@@ -910,6 +944,7 @@
 				B92FB64527058DB5AB9F9D61 /* Assets.xcassets in Resources */,
 				BDDF83B0F7A4BEFAC867D7C9 /* PretendardVariable.ttf in Resources */,
 				7239F0D2A640353BDFB77ECE /* Preview Assets.xcassets in Resources */,
+				E147BC1489860CCA796D0FB3 /* KakaoMapsSDK-SPM_KakaoMapsSDK_SPM.bundle in Resources */,
 				B3FB4F364B89C0E47ED8FDEE /* swift-composable-architecture_ComposableArchitecture.bundle in Resources */,
 				A2DB0250BA4ADFDC53792D00 /* swift-sharing_Sharing.bundle in Resources */,
 			);
@@ -929,6 +964,7 @@
 				9403EC7B879BA24153C5BE55 /* Assets.xcassets in Resources */,
 				CC7CB001DE8D06E58B528C45 /* PretendardVariable.ttf in Resources */,
 				5AF4A31B75E93E65B68F01FC /* Preview Assets.xcassets in Resources */,
+				F4EF4BD55BCFA79F5218F990 /* KakaoMapsSDK-SPM_KakaoMapsSDK_SPM.bundle in Resources */,
 				6A9BD6E561631747BB3C454E /* swift-composable-architecture_ComposableArchitecture.bundle in Resources */,
 				1E10720387A35A97E65C0B2F /* swift-sharing_Sharing.bundle in Resources */,
 			);

--- a/Projects/App/Bangawo.xcodeproj/project.pbxproj
+++ b/Projects/App/Bangawo.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		08369DC313F88F0C31DE7DB4 /* UseCase.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0E592FC14590BBF0BD7DE23F /* UseCase.framework */; };
 		09DFAD4507C3798B653D2804 /* TuistAssets+BangawoDebug.swift in Sources */ = {isa = PBXBuildFile; fileRef = E882E61AE0539644321CD174 /* TuistAssets+BangawoDebug.swift */; };
 		0A2FD72E37198CDF1F6B41C7 /* BangawoApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3657EEDDB069BC04C1808E /* BangawoApp.swift */; };
+		0CB910C7B17DE2EDEC5E31A3 /* KakaoMapsSDK.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1C47D6B037AF1138DB3F3E1C /* KakaoMapsSDK.xcframework */; };
 		0E988E57A80A233ED5874851 /* XCTestDynamicOverlay.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 462D5371FE44F94162F3B51A /* XCTestDynamicOverlay.framework */; };
 		0F1B954379AD48C94A547EA3 /* Model.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3331E5903CD8A0A81A33338B /* Model.framework */; };
 		0F4DE903110E5A7170BF70EC /* OrderedCollections.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5A5421ED7E526F38520B52A2 /* OrderedCollections.framework */; };
@@ -47,6 +48,7 @@
 		29FAA9B0DB7B68A10B6CBD5E /* Foundations.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD7E38252D22390F2ED82261 /* Foundations.framework */; };
 		2AF1F7DB10A8E0306E293747 /* UIKitNavigation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8086E61AF74B835D5FA227D0 /* UIKitNavigation.framework */; };
 		2B1FF2790B3B04C6D02A9C4A /* KakaoMapsSDK-SPM_KakaoMapsSDK_SPM.bundle in Dependencies */ = {isa = PBXBuildFile; fileRef = 6F97AC2A95EA7F5D48A94154 /* KakaoMapsSDK-SPM_KakaoMapsSDK_SPM.bundle */; };
+		304C304D40565C97176AE072 /* KakaoMapsSDK.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1C47D6B037AF1138DB3F3E1C /* KakaoMapsSDK.xcframework */; };
 		30BB0511432CF508D339D2CA /* Model.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3331E5903CD8A0A81A33338B /* Model.framework */; };
 		320710F9420D535135691138 /* CasePathsCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3B7CFA342D1C3F014E295A58 /* CasePathsCore.framework */; };
 		3446857417CDAEF5AB6B2881 /* InternalCollectionsUtilities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 04D0952423F76DEF78CB1221 /* InternalCollectionsUtilities.framework */; };
@@ -62,6 +64,7 @@
 		3F90893C5C4E303DE951DA3C /* IdentifiedCollections.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0A1BE0AC3C1D3386F7B88EDD /* IdentifiedCollections.framework */; };
 		40D8B0927E6FB30E584E1A41 /* InternalCollectionsUtilities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 04D0952423F76DEF78CB1221 /* InternalCollectionsUtilities.framework */; };
 		40FF9DB9A1E3FA2A230B1651 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DD80591ED0247EBC978EA90 /* ContentView.swift */; };
+		44357F6C06FFDE5027EED162 /* KakaoMapsSDK_SPM.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A44FF335B3328D2F9A7964C6 /* KakaoMapsSDK_SPM.framework */; };
 		452C813AFEA7EF2D091F17F8 /* Entity.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EB021004904FC0BC0693A965 /* Entity.framework */; };
 		4723C23A3B29C4D9E7297283 /* UIKitNavigationShim.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 78E3E529753D769C6D4E501C /* UIKitNavigationShim.framework */; };
 		47719C4DCBE2EB18EC9048C0 /* DependenciesMacros.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 84BD81FB92334A2BE51F03F4 /* DependenciesMacros.framework */; };
@@ -81,6 +84,7 @@
 		5AA56FA1E6668190C5B79539 /* swift-composable-architecture_ComposableArchitecture.bundle in Dependencies */ = {isa = PBXBuildFile; fileRef = 7A875D946455A8070B60820F /* swift-composable-architecture_ComposableArchitecture.bundle */; };
 		5AC3E320D1E33300C4E62103 /* DependenciesMacros.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 84BD81FB92334A2BE51F03F4 /* DependenciesMacros.framework */; };
 		5AF4A31B75E93E65B68F01FC /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 8D64641A673A5184FE8C077F /* Preview Assets.xcassets */; };
+		5B8F73B4B3AA00DEEF158039 /* KakaoMapsSDK_SPM.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A44FF335B3328D2F9A7964C6 /* KakaoMapsSDK_SPM.framework */; };
 		5C4638B60A15B266D0478BE6 /* IssueReportingPackageSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5FF209F8D80F33684784A9B4 /* IssueReportingPackageSupport.framework */; };
 		5D19F3626111E2648C83F523 /* BangawoApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3657EEDDB069BC04C1808E /* BangawoApp.swift */; };
 		5D42F470A2BF36CDF88C8D10 /* Clocks.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 45234DE6FD907DA09A3F8F85 /* Clocks.framework */; };
@@ -95,6 +99,7 @@
 		7239F0D2A640353BDFB77ECE /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 8D64641A673A5184FE8C077F /* Preview Assets.xcassets */; };
 		72AB04AD89E5500C3EF59862 /* KakaoMapsSDK-SPM_KakaoMapsSDK_SPM.bundle in Dependencies */ = {isa = PBXBuildFile; fileRef = 6F97AC2A95EA7F5D48A94154 /* KakaoMapsSDK-SPM_KakaoMapsSDK_SPM.bundle */; };
 		7556A391716AB140FB37FB78 /* Repository.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9CB4E6CAC006993A7B6D68BD /* Repository.framework */; };
+		760F56F057AE97A4A27B522A /* KakaoMapsSDK.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1C47D6B037AF1138DB3F3E1C /* KakaoMapsSDK.xcframework */; };
 		762AD4FCD6F1D69EEDDAD845 /* IdentifiedCollections.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0A1BE0AC3C1D3386F7B88EDD /* IdentifiedCollections.framework */; };
 		76A319921C9C80839D9BA0BA /* DomainInterface.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A43A50B926F67FDB8C7C5129 /* DomainInterface.framework */; };
 		77713C685F68858056E0AF7F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DC756959D9071B3202660C14 /* Assets.xcassets */; };
@@ -149,11 +154,13 @@
 		B4EFB288D8B962F093F3B068 /* DataInterface.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E721C7E63953BD446653BC40 /* DataInterface.framework */; };
 		B55E25D81264102D364C7B6A /* ConcurrencyExtras.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 32DBED5A352636241E054A3C /* ConcurrencyExtras.framework */; };
 		B92FB64527058DB5AB9F9D61 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DC756959D9071B3202660C14 /* Assets.xcassets */; };
+		BBFB47354C0D18690ADEBB2B /* KakaoMapsSDK.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1C47D6B037AF1138DB3F3E1C /* KakaoMapsSDK.xcframework */; };
 		BCB14E1E64399A1C6AE93794 /* XCTestDynamicOverlay.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 462D5371FE44F94162F3B51A /* XCTestDynamicOverlay.framework */; };
 		BDAEF1F9E929E2A2B192E1D0 /* Repository.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9CB4E6CAC006993A7B6D68BD /* Repository.framework */; };
 		BDDF83B0F7A4BEFAC867D7C9 /* PretendardVariable.ttf in Resources */ = {isa = PBXBuildFile; fileRef = B4FFF4118A5E3B4B7C441C05 /* PretendardVariable.ttf */; };
 		BE9A9BA6EEF68BDAAFB48AC4 /* CustomDump.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 30CA292DDC8CED1B87D35618 /* CustomDump.framework */; };
 		BF50692D5BCE23EABE32D5F3 /* ComposableArchitecture.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B7709E452C55A8486272F6C1 /* ComposableArchitecture.framework */; };
+		BF94C2411B4412B3780E0534 /* KakaoMapsSDK_SPM.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A44FF335B3328D2F9A7964C6 /* KakaoMapsSDK_SPM.framework */; };
 		C04DF579E8E4CC01E2134985 /* Shared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 77F76D9E4C3C165627C6A49A /* Shared.framework */; };
 		C10570A8411E0FB951FFE14A /* SwiftUINavigation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BF82197E4E96649EA5CAA793 /* SwiftUINavigation.framework */; };
 		C40537828A2A93B4128BFA2F /* IssueReportingPackageSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5FF209F8D80F33684784A9B4 /* IssueReportingPackageSupport.framework */; };
@@ -165,6 +172,7 @@
 		CC4352C88FDCDAD7FADD041A /* PerceptionCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F30F7606920BA74459A75455 /* PerceptionCore.framework */; };
 		CC7CB001DE8D06E58B528C45 /* PretendardVariable.ttf in Resources */ = {isa = PBXBuildFile; fileRef = B4FFF4118A5E3B4B7C441C05 /* PretendardVariable.ttf */; };
 		CC832358653A4AC536B83B29 /* swift-sharing_Sharing.bundle in Resources */ = {isa = PBXBuildFile; fileRef = A68AA2A98B76D10CE538FF88 /* swift-sharing_Sharing.bundle */; };
+		CEBA0ABC78C1485ED38F22CE /* KakaoMapsSDK_SPM.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A44FF335B3328D2F9A7964C6 /* KakaoMapsSDK_SPM.framework */; };
 		CEE96386A24D6A3030F09B00 /* UseCase.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0E592FC14590BBF0BD7DE23F /* UseCase.framework */; };
 		D08F5922B2B7CF5664ADA134 /* Perception.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A76F5409027F278B0373D4F1 /* Perception.framework */; };
 		D0F59AA9B088C2E73E166993 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DD80591ED0247EBC978EA90 /* ContentView.swift */; };
@@ -376,6 +384,7 @@
 		994C17A62B7E2D5E06F40388 /* BangawoTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "BangawoTests-Info.plist"; sourceTree = "<group>"; };
 		9CB4E6CAC006993A7B6D68BD /* Repository.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Repository.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A43A50B926F67FDB8C7C5129 /* DomainInterface.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DomainInterface.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		A44FF335B3328D2F9A7964C6 /* KakaoMapsSDK_SPM.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = KakaoMapsSDK_SPM.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A68AA2A98B76D10CE538FF88 /* swift-sharing_Sharing.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "swift-sharing_Sharing.bundle"; sourceTree = BUILT_PRODUCTS_DIR; };
 		A76F5409027F278B0373D4F1 /* Perception.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Perception.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A9605D64008DC1C1CEFEBAF7 /* Networking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Networking.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -429,6 +438,7 @@
 				0044B1B5407D1A6BB74EA8F0 /* InternalCollectionsUtilities.framework in Frameworks */,
 				E5685E77EF86633B4D04BF5B /* IssueReporting.framework in Frameworks */,
 				5C4638B60A15B266D0478BE6 /* IssueReportingPackageSupport.framework in Frameworks */,
+				BF94C2411B4412B3780E0534 /* KakaoMapsSDK_SPM.framework in Frameworks */,
 				3671BE6506F1D54E22B8F930 /* Model.framework in Frameworks */,
 				90765B81F6F1F0AC22F9E0A5 /* Networking.framework in Frameworks */,
 				0F4DE903110E5A7170BF70EC /* OrderedCollections.framework in Frameworks */,
@@ -445,6 +455,7 @@
 				CB33C4AE01ECB5B336F441B3 /* UIKitNavigationShim.framework in Frameworks */,
 				08369DC313F88F0C31DE7DB4 /* UseCase.framework in Frameworks */,
 				D4AB0432FB440F54CF8BDE50 /* XCTestDynamicOverlay.framework in Frameworks */,
+				760F56F057AE97A4A27B522A /* KakaoMapsSDK.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -469,6 +480,7 @@
 				3446857417CDAEF5AB6B2881 /* InternalCollectionsUtilities.framework in Frameworks */,
 				0123516B5EE729A9FD4A2FFC /* IssueReporting.framework in Frameworks */,
 				C40537828A2A93B4128BFA2F /* IssueReportingPackageSupport.framework in Frameworks */,
+				5B8F73B4B3AA00DEEF158039 /* KakaoMapsSDK_SPM.framework in Frameworks */,
 				30BB0511432CF508D339D2CA /* Model.framework in Frameworks */,
 				D46852FFFCFE97FD18734834 /* Networking.framework in Frameworks */,
 				F1312777E98A5E70FFC389E0 /* OrderedCollections.framework in Frameworks */,
@@ -485,6 +497,7 @@
 				4723C23A3B29C4D9E7297283 /* UIKitNavigationShim.framework in Frameworks */,
 				CEE96386A24D6A3030F09B00 /* UseCase.framework in Frameworks */,
 				0E988E57A80A233ED5874851 /* XCTestDynamicOverlay.framework in Frameworks */,
+				BBFB47354C0D18690ADEBB2B /* KakaoMapsSDK.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -509,6 +522,7 @@
 				40D8B0927E6FB30E584E1A41 /* InternalCollectionsUtilities.framework in Frameworks */,
 				3A1D63344FBD6FE632278E50 /* IssueReporting.framework in Frameworks */,
 				981493132FB545FABF6DE4FB /* IssueReportingPackageSupport.framework in Frameworks */,
+				44357F6C06FFDE5027EED162 /* KakaoMapsSDK_SPM.framework in Frameworks */,
 				E37D7A237F0CB42372C83DA9 /* Model.framework in Frameworks */,
 				973D725839479EF6EC483E61 /* Networking.framework in Frameworks */,
 				8B4B603F58D502BBB5C807BB /* OrderedCollections.framework in Frameworks */,
@@ -525,6 +539,7 @@
 				3DF371ED537CF3DEE709B6BF /* UIKitNavigationShim.framework in Frameworks */,
 				AF5958A2F52624348C9042AF /* UseCase.framework in Frameworks */,
 				4DB37E26F1A280613D4AC4AF /* XCTestDynamicOverlay.framework in Frameworks */,
+				304C304D40565C97176AE072 /* KakaoMapsSDK.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -549,6 +564,7 @@
 				EC7FBC41F7A78198238F7BE3 /* InternalCollectionsUtilities.framework in Frameworks */,
 				A51FFF79B636623F2048B3ED /* IssueReporting.framework in Frameworks */,
 				3CD409C2337A0E4F1E9EEFDA /* IssueReportingPackageSupport.framework in Frameworks */,
+				CEBA0ABC78C1485ED38F22CE /* KakaoMapsSDK_SPM.framework in Frameworks */,
 				0F1B954379AD48C94A547EA3 /* Model.framework in Frameworks */,
 				A3E409A07605E91DA216D813 /* Networking.framework in Frameworks */,
 				0089DC50FADF3A547FFDAB9B /* OrderedCollections.framework in Frameworks */,
@@ -565,6 +581,7 @@
 				7E6174493A14E4C7EFED4308 /* UIKitNavigationShim.framework in Frameworks */,
 				E53686DCA2B18F04393B867B /* UseCase.framework in Frameworks */,
 				BCB14E1E64399A1C6AE93794 /* XCTestDynamicOverlay.framework in Frameworks */,
+				0CB910C7B17DE2EDEC5E31A3 /* KakaoMapsSDK.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -636,6 +653,7 @@
 				04D0952423F76DEF78CB1221 /* InternalCollectionsUtilities.framework */,
 				F6108A4E21485A7C7233D227 /* IssueReporting.framework */,
 				5FF209F8D80F33684784A9B4 /* IssueReportingPackageSupport.framework */,
+				A44FF335B3328D2F9A7964C6 /* KakaoMapsSDK_SPM.framework */,
 				6F97AC2A95EA7F5D48A94154 /* KakaoMapsSDK-SPM_KakaoMapsSDK_SPM.bundle */,
 				3331E5903CD8A0A81A33338B /* Model.framework */,
 				A9605D64008DC1C1CEFEBAF7 /* Networking.framework */,
@@ -1049,6 +1067,10 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				ENABLE_PREVIEWS = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../../Tuist/.build/checkouts/KakaoMapsSDK-SPM/BinaryFramework",
+				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)/../../Tuist/.build/checkouts/swift-navigation/Sources/UIKitNavigationShim/include",
@@ -1103,6 +1125,10 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				ENABLE_PREVIEWS = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../../Tuist/.build/checkouts/KakaoMapsSDK-SPM/BinaryFramework",
+				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)/../../Tuist/.build/checkouts/swift-navigation/Sources/UIKitNavigationShim/include",
@@ -1232,6 +1258,10 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				ENABLE_PREVIEWS = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../../Tuist/.build/checkouts/KakaoMapsSDK-SPM/BinaryFramework",
+				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)/../../Tuist/.build/checkouts/swift-navigation/Sources/UIKitNavigationShim/include",
@@ -1290,6 +1320,10 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				ENABLE_PREVIEWS = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../../Tuist/.build/checkouts/KakaoMapsSDK-SPM/BinaryFramework",
+				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)/../../Tuist/.build/checkouts/swift-navigation/Sources/UIKitNavigationShim/include",
@@ -1344,6 +1378,10 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				ENABLE_PREVIEWS = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../../Tuist/.build/checkouts/KakaoMapsSDK-SPM/BinaryFramework",
+				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)/../../Tuist/.build/checkouts/swift-navigation/Sources/UIKitNavigationShim/include",
@@ -1467,6 +1505,10 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				ENABLE_PREVIEWS = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../../Tuist/.build/checkouts/KakaoMapsSDK-SPM/BinaryFramework",
+				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)/../../Tuist/.build/checkouts/swift-navigation/Sources/UIKitNavigationShim/include",
@@ -1714,6 +1756,10 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				ENABLE_PREVIEWS = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../../Tuist/.build/checkouts/KakaoMapsSDK-SPM/BinaryFramework",
+				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)/../../Tuist/.build/checkouts/swift-navigation/Sources/UIKitNavigationShim/include",
@@ -1768,6 +1814,10 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				ENABLE_PREVIEWS = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../../Tuist/.build/checkouts/KakaoMapsSDK-SPM/BinaryFramework",
+				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)/../../Tuist/.build/checkouts/swift-navigation/Sources/UIKitNavigationShim/include",
@@ -1826,6 +1876,10 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				ENABLE_PREVIEWS = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../../Tuist/.build/checkouts/KakaoMapsSDK-SPM/BinaryFramework",
+				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)/../../Tuist/.build/checkouts/swift-navigation/Sources/UIKitNavigationShim/include",
@@ -1880,6 +1934,10 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				ENABLE_PREVIEWS = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../../Tuist/.build/checkouts/KakaoMapsSDK-SPM/BinaryFramework",
+				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)/../../Tuist/.build/checkouts/swift-navigation/Sources/UIKitNavigationShim/include",
@@ -1934,6 +1992,10 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				ENABLE_PREVIEWS = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../../Tuist/.build/checkouts/KakaoMapsSDK-SPM/BinaryFramework",
+				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)/../../Tuist/.build/checkouts/swift-navigation/Sources/UIKitNavigationShim/include",
@@ -1988,6 +2050,10 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				ENABLE_PREVIEWS = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../../Tuist/.build/checkouts/KakaoMapsSDK-SPM/BinaryFramework",
+				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)/../../Tuist/.build/checkouts/swift-navigation/Sources/UIKitNavigationShim/include",
@@ -2046,6 +2112,10 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				ENABLE_PREVIEWS = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../../Tuist/.build/checkouts/KakaoMapsSDK-SPM/BinaryFramework",
+				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)/../../Tuist/.build/checkouts/swift-navigation/Sources/UIKitNavigationShim/include",
@@ -2273,6 +2343,10 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				ENABLE_PREVIEWS = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../../Tuist/.build/checkouts/KakaoMapsSDK-SPM/BinaryFramework",
+				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)/../../Tuist/.build/checkouts/swift-navigation/Sources/UIKitNavigationShim/include",
@@ -2327,6 +2401,10 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				ENABLE_PREVIEWS = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../../Tuist/.build/checkouts/KakaoMapsSDK-SPM/BinaryFramework",
+				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)/../../Tuist/.build/checkouts/swift-navigation/Sources/UIKitNavigationShim/include",
@@ -2381,6 +2459,10 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				ENABLE_PREVIEWS = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../../Tuist/.build/checkouts/KakaoMapsSDK-SPM/BinaryFramework",
+				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)/../../Tuist/.build/checkouts/swift-navigation/Sources/UIKitNavigationShim/include",

--- a/Projects/App/Derived/InfoPlists/Bangawo-Debug-Info.plist
+++ b/Projects/App/Derived/InfoPlists/Bangawo-Debug-Info.plist
@@ -31,6 +31,8 @@
 	<string>10</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
+	<key>KAKAO_APP_KEY</key>
+	<string>$(KAKAO_APP_KEY)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>

--- a/Projects/App/Derived/InfoPlists/Bangawo-Info.plist
+++ b/Projects/App/Derived/InfoPlists/Bangawo-Info.plist
@@ -31,6 +31,8 @@
 	<string>10</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
+	<key>KAKAO_APP_KEY</key>
+	<string>$(KAKAO_APP_KEY)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>

--- a/Projects/App/Derived/InfoPlists/Bangawo-Prod-Info.plist
+++ b/Projects/App/Derived/InfoPlists/Bangawo-Prod-Info.plist
@@ -31,6 +31,8 @@
 	<string>10</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
+	<key>KAKAO_APP_KEY</key>
+	<string>$(KAKAO_APP_KEY)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>

--- a/Projects/App/Derived/InfoPlists/Bangawo-Stage-Info.plist
+++ b/Projects/App/Derived/InfoPlists/Bangawo-Stage-Info.plist
@@ -31,6 +31,8 @@
 	<string>10</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
+	<key>KAKAO_APP_KEY</key>
+	<string>$(KAKAO_APP_KEY)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>

--- a/Projects/App/Project.swift
+++ b/Projects/App/Project.swift
@@ -10,7 +10,8 @@ let project = Project.makeAppModule(
   settings: .appMainSetting,
   scripts: [],
   dependencies: [
-    .Presentation(implements: .Presentation)
+    .Presentation(implements: .Presentation),
+    .SPM.kakaoMapsSDK
   ],
   sources: ["Sources/**"],
   resources: ["Resources/**"],

--- a/Projects/App/Sources/Application/BangawoApp.swift
+++ b/Projects/App/Sources/Application/BangawoApp.swift
@@ -1,7 +1,14 @@
 import SwiftUI
+@preconcurrency import KakaoMapsSDK
 
 @main
 struct BangawoApp: App {
+    init() {
+        if let appKey = Bundle.main.infoDictionary?["KAKAO_APP_KEY"] as? String, !appKey.isEmpty {
+            SDKInitializer.InitSDK(appKey: appKey, phase: .real)
+        }
+    }
+
     var body: some Scene {
         WindowGroup {
             ContentView()

--- a/Projects/Shared/DesignSystem/DesignSystem.xcodeproj/project.pbxproj
+++ b/Projects/Shared/DesignSystem/DesignSystem.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		BCA453C0D05C32C4A63CB8C4 /* UIColor+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F71885338F6DE555D4751C4 /* UIColor+.swift */; };
 		C83CACD5B5F275224A93814E /* ImageAsset.swift in Sources */ = {isa = PBXBuildFile; fileRef = D199440E65D8D401EDC98511 /* ImageAsset.swift */; };
 		CEC36DC0BC8D2AF0871D6E58 /* Color+.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE4AC63533057A09401E9ACB /* Color+.swift */; };
+		E367662901E0F401ACB60488 /* KakaoMapsSDK_SPM.framework in Dependencies */ = {isa = PBXBuildFile; fileRef = 42A051D576F50390B143C516 /* KakaoMapsSDK_SPM.framework */; };
 		E79FE8601AE837DBF04B8E00 /* ImageAssets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 365911FA35B2B70671D60856 /* ImageAssets.xcassets */; };
 		F6018B5F7748E322214C52D6 /* TuistBundle+DesignSystem.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE4AD9735556ECA8C8008FEC /* TuistBundle+DesignSystem.swift */; };
 		F80C933AD43E1B03AD6D666E /* UIScreen+.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7244267FD9E30E6D6ACDDB2 /* UIScreen+.swift */; };
@@ -37,6 +38,16 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
+		261A68F06D4B4813FC5879A5 /* Dependencies */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 8;
+			dstSubfolderSpec = 16;
+			files = (
+				E367662901E0F401ACB60488 /* KakaoMapsSDK_SPM.framework in Dependencies */,
+			);
+			name = Dependencies;
+			runOnlyForDeploymentPostprocessing = 1;
+		};
 		3FBA6A1C0FF2C099107F7C40 /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -64,6 +75,7 @@
 		1FE7959C58FBD17C719858D1 /* ShapeStyle+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ShapeStyle+.swift"; sourceTree = "<group>"; };
 		365911FA35B2B70671D60856 /* ImageAssets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = ImageAssets.xcassets; sourceTree = "<group>"; };
 		41EFBC8F3B807CE0659AA912 /* UIImage+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+.swift"; sourceTree = "<group>"; };
+		42A051D576F50390B143C516 /* KakaoMapsSDK_SPM.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = KakaoMapsSDK_SPM.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		42D7C40704F4FCBCDB855667 /* DesignSystem_DesignSystem.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DesignSystem_DesignSystem.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
 		593CD7BFBE22E5E79F338306 /* Image+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Image+.swift"; sourceTree = "<group>"; };
 		5DFDEE116A67E6C3606007A2 /* PretendardFontFamily.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PretendardFontFamily.swift; sourceTree = "<group>"; };
@@ -169,6 +181,7 @@
 			children = (
 				42D7C40704F4FCBCDB855667 /* DesignSystem_DesignSystem.bundle */,
 				69B7BBEAD5472C7195924AC8 /* DesignSystem.framework */,
+				42A051D576F50390B143C516 /* KakaoMapsSDK_SPM.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -273,6 +286,7 @@
 				510D3A5EADC65A3BE366D353 /* Resources */,
 				21D2E38EFDFDB350406F7982 /* Frameworks */,
 				49C4A8593835DDF36FBC2A05 /* Embed Frameworks */,
+				261A68F06D4B4813FC5879A5 /* Dependencies */,
 			);
 			buildRules = (
 			);

--- a/Projects/Shared/DesignSystem/DesignSystem.xcodeproj/project.pbxproj
+++ b/Projects/Shared/DesignSystem/DesignSystem.xcodeproj/project.pbxproj
@@ -17,10 +17,13 @@
 		5F05FF5EC1CA585CDFEC110F /* UINavigationController+gesture.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2FF3EE78E7FC222C9E4E71 /* UINavigationController+gesture.swift */; };
 		64F162B159C0BD3427E9096D /* PretendardFontFamily.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DFDEE116A67E6C3606007A2 /* PretendardFontFamily.swift */; };
 		7E7556D460CA653711A5A114 /* ShapeStyle+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FE7959C58FBD17C719858D1 /* ShapeStyle+.swift */; };
+		94F7264F28DCF1E7613C4EFC /* KakaoMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFEB58C89AD06A3247AA148A /* KakaoMap.swift */; };
 		ABB14811E13F7B1ECCF8B086 /* TuistAssets+DesignSystem.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5263BC75B281154AC0B5A7B /* TuistAssets+DesignSystem.swift */; };
+		AFC846023F09506196E94B1E /* KakaoMapRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8F4FA46575FB210C17B177B /* KakaoMapRepresentable.swift */; };
 		BCA453C0D05C32C4A63CB8C4 /* UIColor+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F71885338F6DE555D4751C4 /* UIColor+.swift */; };
 		C83CACD5B5F275224A93814E /* ImageAsset.swift in Sources */ = {isa = PBXBuildFile; fileRef = D199440E65D8D401EDC98511 /* ImageAsset.swift */; };
 		CEC36DC0BC8D2AF0871D6E58 /* Color+.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE4AC63533057A09401E9ACB /* Color+.swift */; };
+		CF9161C23854D687C3E65AB4 /* MapModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AD63FD8391E885972624FE2 /* MapModel.swift */; };
 		E367662901E0F401ACB60488 /* KakaoMapsSDK_SPM.framework in Dependencies */ = {isa = PBXBuildFile; fileRef = 42A051D576F50390B143C516 /* KakaoMapsSDK_SPM.framework */; };
 		E79FE8601AE837DBF04B8E00 /* ImageAssets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 365911FA35B2B70671D60856 /* ImageAssets.xcassets */; };
 		F6018B5F7748E322214C52D6 /* TuistBundle+DesignSystem.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE4AD9735556ECA8C8008FEC /* TuistBundle+DesignSystem.swift */; };
@@ -84,10 +87,13 @@
 		6F71885338F6DE555D4751C4 /* UIColor+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+.swift"; sourceTree = "<group>"; };
 		8050F7F529EDCCDC9DFBAD9A /* CustomSize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomSize.swift; sourceTree = "<group>"; };
 		8937FA9427EEA938B58C5B3E /* DesignSystem-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "DesignSystem-Info.plist"; sourceTree = "<group>"; };
+		9AD63FD8391E885972624FE2 /* MapModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapModel.swift; sourceTree = "<group>"; };
 		A20647CF23B131D16DCAB555 /* PretendardVariable.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = PretendardVariable.ttf; sourceTree = "<group>"; };
 		A5263BC75B281154AC0B5A7B /* TuistAssets+DesignSystem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TuistAssets+DesignSystem.swift"; sourceTree = "<group>"; };
 		A7244267FD9E30E6D6ACDDB2 /* UIScreen+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIScreen+.swift"; sourceTree = "<group>"; };
 		BE4AD9735556ECA8C8008FEC /* TuistBundle+DesignSystem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TuistBundle+DesignSystem.swift"; sourceTree = "<group>"; };
+		C8F4FA46575FB210C17B177B /* KakaoMapRepresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KakaoMapRepresentable.swift; sourceTree = "<group>"; };
+		CFEB58C89AD06A3247AA148A /* KakaoMap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KakaoMap.swift; sourceTree = "<group>"; };
 		D199440E65D8D401EDC98511 /* ImageAsset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageAsset.swift; sourceTree = "<group>"; };
 		DDA12AD00E98A3497D3A729E /* DesignSystem_DesignSystem-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "DesignSystem_DesignSystem-Info.plist"; sourceTree = "<group>"; };
 		DE2FF3EE78E7FC222C9E4E71 /* UINavigationController+gesture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UINavigationController+gesture.swift"; sourceTree = "<group>"; };
@@ -129,6 +135,7 @@
 				07B3C6779FC95ED6B892F6E8 /* CustomFont */,
 				DADCA588D3E296D27BE4E9DD /* Extension */,
 				3D56AC3DF263FFE10ECDAF91 /* Image */,
+				B9C37AE02C3B2BEB3348A016 /* Map */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -202,6 +209,16 @@
 				365911FA35B2B70671D60856 /* ImageAssets.xcassets */,
 			);
 			path = Resources;
+			sourceTree = "<group>";
+		};
+		B9C37AE02C3B2BEB3348A016 /* Map */ = {
+			isa = PBXGroup;
+			children = (
+				CFEB58C89AD06A3247AA148A /* KakaoMap.swift */,
+				C8F4FA46575FB210C17B177B /* KakaoMapRepresentable.swift */,
+				9AD63FD8391E885972624FE2 /* MapModel.swift */,
+			);
+			path = Map;
 			sourceTree = "<group>";
 		};
 		CF270952CD15E112A8DAB3B5 /* UI */ = {
@@ -395,6 +412,9 @@
 				F80C933AD43E1B03AD6D666E /* UIScreen+.swift in Sources */,
 				5F05FF5EC1CA585CDFEC110F /* UINavigationController+gesture.swift in Sources */,
 				C83CACD5B5F275224A93814E /* ImageAsset.swift in Sources */,
+				94F7264F28DCF1E7613C4EFC /* KakaoMap.swift in Sources */,
+				AFC846023F09506196E94B1E /* KakaoMapRepresentable.swift in Sources */,
+				CF9161C23854D687C3E65AB4 /* MapModel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Projects/Shared/DesignSystem/Project.swift
+++ b/Projects/Shared/DesignSystem/Project.swift
@@ -10,7 +10,7 @@ let project = Project.makeModule(
   product: .staticFramework,
   settings:  .settings(),
   dependencies: [
-
+    .SPM.kakaoMapsSDK
   ],
   sources: ["Sources/**"],
   resources: ["Resources/**", "FontAsset/**"],

--- a/Projects/Shared/DesignSystem/Sources/Map/KakaoMap.swift
+++ b/Projects/Shared/DesignSystem/Sources/Map/KakaoMap.swift
@@ -6,6 +6,8 @@ public struct KakaoMap: View {
     private let initialCenter: MapCoordinate
     private let initialZoomLevel: Int
     private var onPinTapped: ((MapPin) -> Void)?
+    
+    @State private var isVisible: Bool = false
 
     public init(
         routes: [MapRoute] = [],
@@ -27,11 +29,18 @@ public struct KakaoMap: View {
 
     public var body: some View {
         KakaoMapRepresentable(
+            isVisible: $isVisible,
             routes: routes,
             pins: pins,
             initialCenter: initialCenter,
             initialZoomLevel: initialZoomLevel,
             onPinTapped: onPinTapped
         )
+        .onAppear {
+            self.isVisible = true
+        }
+        .onDisappear {
+            self.isVisible = false
+        }
     }
 }

--- a/Projects/Shared/DesignSystem/Sources/Map/KakaoMap.swift
+++ b/Projects/Shared/DesignSystem/Sources/Map/KakaoMap.swift
@@ -7,6 +7,8 @@ public struct KakaoMap: View {
     private let initialZoomLevel: Int
     private var onPinTapped: ((MapPin) -> Void)?
     
+    /// 화면 이탈/재진입 시 엔진을 토글하기 위한 상태값.
+    /// onAppear(true) → activateEngine, onDisappear(false) → resetEngine
     @State private var isVisible: Bool = false
 
     public init(

--- a/Projects/Shared/DesignSystem/Sources/Map/KakaoMap.swift
+++ b/Projects/Shared/DesignSystem/Sources/Map/KakaoMap.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+public struct KakaoMap: View {
+    private let routes: [MapRoute]
+    private let pins: [MapPin]
+    private let initialCenter: MapCoordinate
+    private let initialZoomLevel: Int
+    private var onPinTapped: ((MapPin) -> Void)?
+
+    public init(
+        routes: [MapRoute] = [],
+        pins: [MapPin] = [],
+        initialCenter: MapCoordinate,
+        initialZoomLevel: Int = 15
+    ) {
+        self.routes = routes
+        self.pins = pins
+        self.initialCenter = initialCenter
+        self.initialZoomLevel = initialZoomLevel
+    }
+
+    public func onPinTapped(_ handler: @escaping (MapPin) -> Void) -> KakaoMap {
+        var copy = self
+        copy.onPinTapped = handler
+        return copy
+    }
+
+    public var body: some View {
+        KakaoMapRepresentable(
+            routes: routes,
+            pins: pins,
+            initialCenter: initialCenter,
+            initialZoomLevel: initialZoomLevel,
+            onPinTapped: onPinTapped
+        )
+    }
+}

--- a/Projects/Shared/DesignSystem/Sources/Map/KakaoMapRepresentable.swift
+++ b/Projects/Shared/DesignSystem/Sources/Map/KakaoMapRepresentable.swift
@@ -13,9 +13,19 @@ struct KakaoMapRepresentable: UIViewRepresentable {
         let container = KMViewContainer()
         context.coordinator.container = container
         context.coordinator.createController(container: container)
+        // 다음 run loop에서 엔진을 준비한다.
+        // 현재 run loop에서는 Auto Layout이 완료되지 않아 bounds가 .zero일 수 있으므로,
+        // 레이아웃 커밋 이후 시점으로 미뤄 SDK가 정상적인 렌더 서피스를 생성하도록 한다.
+        DispatchQueue.main.async {
+            context.coordinator.controller?.prepareEngine()
+        }
         return container
     }
 
+    // SDK 엔진 라이프사이클: prepareEngine → 인증 → activateEngine → addViews → 맵 렌더링
+    // prepareEngine은 makeUIView에서 1회 호출하고,
+    // activateEngine은 authenticationSucceeded 델리게이트에서 호출한다.
+    // updateUIView는 화면 재진입(isVisible 토글) 시 엔진을 활성화/비활성화하는 역할만 담당한다.
     func updateUIView(_ uiView: KMViewContainer, context: Context) {
         let coordinator = context.coordinator
         coordinator.pendingRoutes = routes
@@ -23,24 +33,12 @@ struct KakaoMapRepresentable: UIViewRepresentable {
         coordinator.onPinTapped = onPinTapped
 
         if isVisible {
-            // KakaoMapSDK는 KMViewContainer의 bounds 기반으로 렌더 서피스를 생성한다.
-            // onAppear 시점에도 Auto Layout + CALayer 커밋이 완료되지 않을 수 있어
-            // 0.5초 지연 후 SDK 자체 상태를 확인하여 엔진을 초기화한다.
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                if coordinator.controller?.isEnginePrepared == false {
-                    coordinator.controller?.prepareEngine()
-                }
-
-                if coordinator.controller?.isEngineActive == false {
-                    coordinator.controller?.activateEngine()
-                }
-            }
+            coordinator.controller?.activateEngine()
 
             if coordinator.isMapReady {
                 coordinator.applyOverlays()
             }
         } else {
-            coordinator.controller?.pauseEngine()
             coordinator.controller?.resetEngine()
         }
     }
@@ -125,7 +123,6 @@ struct KakaoMapRepresentable: UIViewRepresentable {
             }
             mapView.eventDelegate = self
             isMapReady = true
-            controller?.activateEngine()
             applyOverlays()
         }
 
@@ -134,8 +131,14 @@ struct KakaoMapRepresentable: UIViewRepresentable {
             isMapReady = false
         }
 
+        // 인증 성공 후 엔진을 활성화한다.
+        // SDK 라이프사이클상 activateEngine()의 최초 호출 지점이다.
+        // 이후 addViews → addViewSucceeded 순서로 맵 렌더링이 진행된다.
         func authenticationSucceeded() {
             print("[KakaoMap] Authentication succeeded")
+            if controller?.isEngineActive == false {
+                controller?.activateEngine()
+            }
         }
 
         func authenticationFailed(_ errorCode: Int, desc: String) {

--- a/Projects/Shared/DesignSystem/Sources/Map/KakaoMapRepresentable.swift
+++ b/Projects/Shared/DesignSystem/Sources/Map/KakaoMapRepresentable.swift
@@ -2,6 +2,8 @@
 import SwiftUI
 
 struct KakaoMapRepresentable: UIViewRepresentable {
+    /// 화면 이탈/재진입 시 엔진을 토글하기 위한 상태값.
+    /// onAppear(true) → activateEngine, onDisappear(false) → resetEngine
     @Binding var isVisible: Bool
     let routes: [MapRoute]
     let pins: [MapPin]
@@ -99,15 +101,14 @@ struct KakaoMapRepresentable: UIViewRepresentable {
         // MARK: - MapControllerDelegate
 
         func addViews() {
-            print("[KakaoMap] addViews called - container frame: \(container?.frame ?? .zero)")
             let defaultPosition = MapPoint(
                 longitude: initialCenter.longitude,
                 latitude: initialCenter.latitude
             )
             let mapviewInfo = MapviewInfo(
-                viewName: "bangawo_map",
-                appName: "openmap",
-                viewInfoName: "map",
+                viewName: MapIdentifier.viewName,
+                appName: MapIdentifier.appName,
+                viewInfoName: MapIdentifier.viewInfoName,
                 defaultPosition: defaultPosition,
                 defaultLevel: initialZoomLevel,
                 enabled: true
@@ -116,8 +117,8 @@ struct KakaoMapRepresentable: UIViewRepresentable {
         }
 
         func addViewSucceeded(_ viewName: String, viewInfoName: String) {
-            print("[KakaoMap] addViewSucceeded - viewName: \(viewName), container frame: \(container?.frame ?? .zero)")
             guard let mapView = controller?.getView(viewName) as? KakaoMapsSDK.KakaoMap else {
+                // TODO: Logger로 대체
                 print("[KakaoMap] getView failed - could not cast to KakaoMap")
                 return
             }
@@ -127,6 +128,7 @@ struct KakaoMapRepresentable: UIViewRepresentable {
         }
 
         func addViewFailed(_ viewName: String, viewInfoName: String) {
+            // TODO: Logger로 대체
             print("[KakaoMap] addView failed - viewName: \(viewName), viewInfoName: \(viewInfoName)")
             isMapReady = false
         }
@@ -135,13 +137,13 @@ struct KakaoMapRepresentable: UIViewRepresentable {
         // SDK 라이프사이클상 activateEngine()의 최초 호출 지점이다.
         // 이후 addViews → addViewSucceeded 순서로 맵 렌더링이 진행된다.
         func authenticationSucceeded() {
-            print("[KakaoMap] Authentication succeeded")
             if controller?.isEngineActive == false {
                 controller?.activateEngine()
             }
         }
 
         func authenticationFailed(_ errorCode: Int, desc: String) {
+            // TODO: Logger로 대체
             print("[KakaoMap] Authentication failed - code: \(errorCode), desc: \(desc)")
         }
 
@@ -156,7 +158,7 @@ struct KakaoMapRepresentable: UIViewRepresentable {
 
         func applyOverlays() {
             guard isMapReady,
-                  let mapView = controller?.getView("bangawo_map") as? KakaoMapsSDK.KakaoMap
+                  let mapView = controller?.getView(MapIdentifier.viewName) as? KakaoMapsSDK.KakaoMap
             else { return }
 
             if pendingRoutes != currentRoutes {
@@ -172,11 +174,11 @@ struct KakaoMapRepresentable: UIViewRepresentable {
 
         private func applyRoutes(_ routes: [MapRoute], on mapView: KakaoMapsSDK.KakaoMap) {
             let shapeManager = mapView.getShapeManager()
-            shapeManager.removeShapeLayer(layerID: "bangawo_polyline_layer")
+            shapeManager.removeShapeLayer(layerID: MapIdentifier.polylineLayer)
 
             guard !routes.isEmpty else { return }
 
-            let styleSetID = "bangawo_polyline_styles"
+            let styleSetID = MapIdentifier.polylineStyleSet
 
             var polylineStyles: [PolylineStyle] = []
             for route in routes {
@@ -194,7 +196,7 @@ struct KakaoMapRepresentable: UIViewRepresentable {
             shapeManager.addPolylineStyleSet(styleSet)
 
             guard let layer = shapeManager.addShapeLayer(
-                layerID: "bangawo_polyline_layer",
+                layerID: MapIdentifier.polylineLayer,
                 zOrder: 1,
                 passType: .route
             ) else { return }
@@ -208,7 +210,7 @@ struct KakaoMapRepresentable: UIViewRepresentable {
             }
 
             let shapeOptions = MapPolylineShapeOptions(
-                shapeID: "bangawo_polylines",
+                shapeID: MapIdentifier.polylineShape,
                 styleID: styleSetID,
                 zOrder: 0
             )
@@ -221,13 +223,13 @@ struct KakaoMapRepresentable: UIViewRepresentable {
 
         private func applyPins(_ pins: [MapPin], on mapView: KakaoMapsSDK.KakaoMap) {
             let labelManager = mapView.getLabelManager()
-            labelManager.removeLabelLayer(layerID: "bangawo_pin_layer")
+            labelManager.removeLabelLayer(layerID: MapIdentifier.pinLayer)
             pinMap.removeAll()
 
             guard !pins.isEmpty else { return }
 
             for (index, pin) in pins.enumerated() {
-                let styleID = "bangawo_pin_style_\(index)"
+                let styleID = MapIdentifier.pinStyle(index: index)
                 let iconStyle: PoiIconStyle
                 if let image = pin.iconImage {
                     iconStyle = PoiIconStyle(symbol: image, anchorPoint: CGPoint(x: 0.5, y: 1.0))
@@ -240,7 +242,7 @@ struct KakaoMapRepresentable: UIViewRepresentable {
             }
 
             let layerOptions = LabelLayerOptions(
-                layerID: "bangawo_pin_layer",
+                layerID: MapIdentifier.pinLayer,
                 competitionType: .none,
                 competitionUnit: .poi,
                 orderType: .rank,
@@ -250,7 +252,7 @@ struct KakaoMapRepresentable: UIViewRepresentable {
             layer.setClickable(true)
 
             for (index, pin) in pins.enumerated() {
-                let styleID = "bangawo_pin_style_\(index)"
+                let styleID = MapIdentifier.pinStyle(index: index)
                 let options = PoiOptions(styleID: styleID, poiID: pin.id)
                 options.rank = index
                 options.clickable = true
@@ -282,5 +284,21 @@ struct KakaoMapRepresentable: UIViewRepresentable {
                 ctx.fillEllipse(in: innerCircle)
             }
         }
+    }
+}
+
+// MARK: - Constants
+
+private enum MapIdentifier {
+    static let viewName = "bangawo_map"
+    static let appName = "openmap"
+    static let viewInfoName = "map"
+    static let polylineLayer = "bangawo_polyline_layer"
+    static let polylineStyleSet = "bangawo_polyline_styles"
+    static let polylineShape = "bangawo_polylines"
+    static let pinLayer = "bangawo_pin_layer"
+
+    static func pinStyle(index: Int) -> String {
+        "bangawo_pin_style_\(index)"
     }
 }

--- a/Projects/Shared/DesignSystem/Sources/Map/KakaoMapRepresentable.swift
+++ b/Projects/Shared/DesignSystem/Sources/Map/KakaoMapRepresentable.swift
@@ -1,0 +1,256 @@
+@preconcurrency import KakaoMapsSDK
+import SwiftUI
+
+struct KakaoMapRepresentable: UIViewRepresentable {
+    let routes: [MapRoute]
+    let pins: [MapPin]
+    let initialCenter: MapCoordinate
+    let initialZoomLevel: Int
+    var onPinTapped: ((MapPin) -> Void)?
+
+    func makeUIView(context: Context) -> KMViewContainer {
+        let container = KMViewContainer()
+        context.coordinator.container = container
+        context.coordinator.createController(container: container)
+        return container
+    }
+
+    func updateUIView(_ uiView: KMViewContainer, context: Context) {
+        let coordinator = context.coordinator
+        coordinator.pendingRoutes = routes
+        coordinator.pendingPins = pins
+        coordinator.onPinTapped = onPinTapped
+
+        if coordinator.isMapReady {
+            coordinator.applyOverlays()
+        }
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(
+            routes: routes,
+            pins: pins,
+            initialCenter: initialCenter,
+            initialZoomLevel: initialZoomLevel,
+            onPinTapped: onPinTapped
+        )
+    }
+
+    static func dismantleUIView(_ uiView: KMViewContainer, coordinator: Coordinator) {
+        coordinator.controller?.pauseEngine()
+        coordinator.controller?.resetEngine()
+    }
+
+    // MARK: - Coordinator
+
+    final class Coordinator: NSObject, MapControllerDelegate, KakaoMapEventDelegate {
+        weak var container: KMViewContainer?
+        var controller: KMController?
+        var isMapReady = false
+
+        var pendingRoutes: [MapRoute]
+        var pendingPins: [MapPin]
+        var onPinTapped: ((MapPin) -> Void)?
+
+        private let initialCenter: MapCoordinate
+        private let initialZoomLevel: Int
+
+        private var currentRoutes: [MapRoute] = []
+        private var currentPins: [MapPin] = []
+        private var pinMap: [String: MapPin] = [:]
+
+        init(
+            routes: [MapRoute],
+            pins: [MapPin],
+            initialCenter: MapCoordinate,
+            initialZoomLevel: Int,
+            onPinTapped: ((MapPin) -> Void)?
+        ) {
+            self.pendingRoutes = routes
+            self.pendingPins = pins
+            self.initialCenter = initialCenter
+            self.initialZoomLevel = initialZoomLevel
+            self.onPinTapped = onPinTapped
+        }
+
+        func createController(container: KMViewContainer) {
+            controller = KMController(viewContainer: container)
+            controller?.delegate = self
+            controller?.prepareEngine()
+        }
+
+        // MARK: - MapControllerDelegate
+
+        func addViews() {
+            let defaultPosition = MapPoint(
+                longitude: initialCenter.longitude,
+                latitude: initialCenter.latitude
+            )
+            let mapviewInfo = MapviewInfo(
+                viewName: "bangawo_map",
+                appName: "openmap",
+                viewInfoName: "map",
+                defaultPosition: defaultPosition,
+                defaultLevel: initialZoomLevel,
+                enabled: true
+            )
+            controller?.addView(mapviewInfo)
+        }
+
+        func addViewSucceeded(_ viewName: String, viewInfoName: String) {
+            guard let mapView = controller?.getView(viewName) as? KakaoMapsSDK.KakaoMap else {
+                return
+            }
+            mapView.eventDelegate = self
+            isMapReady = true
+            controller?.activateEngine()
+            applyOverlays()
+        }
+
+        func addViewFailed(_ viewName: String, viewInfoName: String) {
+            isMapReady = false
+        }
+
+        func authenticationSucceeded() {}
+
+        func authenticationFailed(_ errorCode: Int, desc: String) {}
+
+        // MARK: - KakaoMapEventDelegate
+
+        func poiDidTapped(kakaoMap: KakaoMapsSDK.KakaoMap, layerID: String, poiID: String, position: MapPoint) {
+            guard let pin = pinMap[poiID] else { return }
+            onPinTapped?(pin)
+        }
+
+        // MARK: - Overlay Management
+
+        func applyOverlays() {
+            guard isMapReady,
+                  let mapView = controller?.getView("bangawo_map") as? KakaoMapsSDK.KakaoMap
+            else { return }
+
+            if pendingRoutes != currentRoutes {
+                applyRoutes(pendingRoutes, on: mapView)
+                currentRoutes = pendingRoutes
+            }
+
+            if pendingPins != currentPins {
+                applyPins(pendingPins, on: mapView)
+                currentPins = pendingPins
+            }
+        }
+
+        private func applyRoutes(_ routes: [MapRoute], on mapView: KakaoMapsSDK.KakaoMap) {
+            let shapeManager = mapView.getShapeManager()
+            shapeManager.removeShapeLayer(layerID: "bangawo_polyline_layer")
+
+            guard !routes.isEmpty else { return }
+
+            let styleSetID = "bangawo_polyline_styles"
+
+            var polylineStyles: [PolylineStyle] = []
+            for route in routes {
+                let perLevel = PerLevelPolylineStyle(
+                    bodyColor: route.lineColor,
+                    bodyWidth: route.lineWidth,
+                    strokeColor: route.strokeColor,
+                    strokeWidth: route.strokeWidth,
+                    level: 0
+                )
+                polylineStyles.append(PolylineStyle(styles: [perLevel]))
+            }
+
+            let styleSet = PolylineStyleSet(styleSetID: styleSetID, styles: polylineStyles, capType: .round)
+            shapeManager.addPolylineStyleSet(styleSet)
+
+            guard let layer = shapeManager.addShapeLayer(
+                layerID: "bangawo_polyline_layer",
+                zOrder: 1,
+                passType: .route
+            ) else { return }
+
+            var polylines: [MapPolyline] = []
+            for (index, route) in routes.enumerated() {
+                let points = route.coordinates.map {
+                    MapPoint(longitude: $0.longitude, latitude: $0.latitude)
+                }
+                polylines.append(MapPolyline(line: points, styleIndex: UInt(index)))
+            }
+
+            let shapeOptions = MapPolylineShapeOptions(
+                shapeID: "bangawo_polylines",
+                styleID: styleSetID,
+                zOrder: 0
+            )
+            shapeOptions.polylines = polylines
+
+            if let shape = layer.addMapPolylineShape(shapeOptions, callback: nil) {
+                shape.show()
+            }
+        }
+
+        private func applyPins(_ pins: [MapPin], on mapView: KakaoMapsSDK.KakaoMap) {
+            let labelManager = mapView.getLabelManager()
+            labelManager.removeLabelLayer(layerID: "bangawo_pin_layer")
+            pinMap.removeAll()
+
+            guard !pins.isEmpty else { return }
+
+            for (index, pin) in pins.enumerated() {
+                let styleID = "bangawo_pin_style_\(index)"
+                let iconStyle: PoiIconStyle
+                if let image = pin.iconImage {
+                    iconStyle = PoiIconStyle(symbol: image, anchorPoint: CGPoint(x: 0.5, y: 1.0))
+                } else {
+                    iconStyle = PoiIconStyle(symbol: defaultPinImage(), anchorPoint: CGPoint(x: 0.5, y: 1.0))
+                }
+                let perLevel = PerLevelPoiStyle(iconStyle: iconStyle, level: 0)
+                let poiStyle = PoiStyle(styleID: styleID, styles: [perLevel])
+                labelManager.addPoiStyle(poiStyle)
+            }
+
+            let layerOptions = LabelLayerOptions(
+                layerID: "bangawo_pin_layer",
+                competitionType: .none,
+                competitionUnit: .poi,
+                orderType: .rank,
+                zOrder: 10001
+            )
+            guard let layer = labelManager.addLabelLayer(option: layerOptions) else { return }
+            layer.setClickable(true)
+
+            for (index, pin) in pins.enumerated() {
+                let styleID = "bangawo_pin_style_\(index)"
+                let options = PoiOptions(styleID: styleID, poiID: pin.id)
+                options.rank = index
+                options.clickable = true
+
+                let position = MapPoint(longitude: pin.coordinate.longitude, latitude: pin.coordinate.latitude)
+                if let poi = layer.addPoi(option: options, at: position, callback: nil) {
+                    poi.show()
+                }
+                pinMap[pin.id] = pin
+            }
+        }
+
+        private func defaultPinImage() -> UIImage {
+            let size = CGSize(width: 24, height: 36)
+            let renderer = UIGraphicsImageRenderer(size: size)
+            return renderer.image { context in
+                let ctx = context.cgContext
+                UIColor.systemRed.setFill()
+                let circleRect = CGRect(x: 4, y: 4, width: 16, height: 16)
+                ctx.fillEllipse(in: circleRect)
+                let trianglePath = UIBezierPath()
+                trianglePath.move(to: CGPoint(x: 4, y: 16))
+                trianglePath.addLine(to: CGPoint(x: 12, y: 36))
+                trianglePath.addLine(to: CGPoint(x: 20, y: 16))
+                trianglePath.close()
+                trianglePath.fill()
+                UIColor.white.setFill()
+                let innerCircle = CGRect(x: 8, y: 8, width: 8, height: 8)
+                ctx.fillEllipse(in: innerCircle)
+            }
+        }
+    }
+}

--- a/Projects/Shared/DesignSystem/Sources/Map/KakaoMapRepresentable.swift
+++ b/Projects/Shared/DesignSystem/Sources/Map/KakaoMapRepresentable.swift
@@ -2,6 +2,7 @@
 import SwiftUI
 
 struct KakaoMapRepresentable: UIViewRepresentable {
+    @Binding var isVisible: Bool
     let routes: [MapRoute]
     let pins: [MapPin]
     let initialCenter: MapCoordinate
@@ -21,8 +22,26 @@ struct KakaoMapRepresentable: UIViewRepresentable {
         coordinator.pendingPins = pins
         coordinator.onPinTapped = onPinTapped
 
-        if coordinator.isMapReady {
-            coordinator.applyOverlays()
+        if isVisible {
+            // KakaoMapSDK는 KMViewContainer의 bounds 기반으로 렌더 서피스를 생성한다.
+            // onAppear 시점에도 Auto Layout + CALayer 커밋이 완료되지 않을 수 있어
+            // 0.5초 지연 후 SDK 자체 상태를 확인하여 엔진을 초기화한다.
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                if coordinator.controller?.isEnginePrepared == false {
+                    coordinator.controller?.prepareEngine()
+                }
+
+                if coordinator.controller?.isEngineActive == false {
+                    coordinator.controller?.activateEngine()
+                }
+            }
+
+            if coordinator.isMapReady {
+                coordinator.applyOverlays()
+            }
+        } else {
+            coordinator.controller?.pauseEngine()
+            coordinator.controller?.resetEngine()
         }
     }
 
@@ -47,6 +66,7 @@ struct KakaoMapRepresentable: UIViewRepresentable {
         weak var container: KMViewContainer?
         var controller: KMController?
         var isMapReady = false
+        var isEnginePrepared = false
 
         var pendingRoutes: [MapRoute]
         var pendingPins: [MapPin]
@@ -76,12 +96,12 @@ struct KakaoMapRepresentable: UIViewRepresentable {
         func createController(container: KMViewContainer) {
             controller = KMController(viewContainer: container)
             controller?.delegate = self
-            controller?.prepareEngine()
         }
 
         // MARK: - MapControllerDelegate
 
         func addViews() {
+            print("[KakaoMap] addViews called - container frame: \(container?.frame ?? .zero)")
             let defaultPosition = MapPoint(
                 longitude: initialCenter.longitude,
                 latitude: initialCenter.latitude
@@ -98,7 +118,9 @@ struct KakaoMapRepresentable: UIViewRepresentable {
         }
 
         func addViewSucceeded(_ viewName: String, viewInfoName: String) {
+            print("[KakaoMap] addViewSucceeded - viewName: \(viewName), container frame: \(container?.frame ?? .zero)")
             guard let mapView = controller?.getView(viewName) as? KakaoMapsSDK.KakaoMap else {
+                print("[KakaoMap] getView failed - could not cast to KakaoMap")
                 return
             }
             mapView.eventDelegate = self
@@ -108,12 +130,17 @@ struct KakaoMapRepresentable: UIViewRepresentable {
         }
 
         func addViewFailed(_ viewName: String, viewInfoName: String) {
+            print("[KakaoMap] addView failed - viewName: \(viewName), viewInfoName: \(viewInfoName)")
             isMapReady = false
         }
 
-        func authenticationSucceeded() {}
+        func authenticationSucceeded() {
+            print("[KakaoMap] Authentication succeeded")
+        }
 
-        func authenticationFailed(_ errorCode: Int, desc: String) {}
+        func authenticationFailed(_ errorCode: Int, desc: String) {
+            print("[KakaoMap] Authentication failed - code: \(errorCode), desc: \(desc)")
+        }
 
         // MARK: - KakaoMapEventDelegate
 

--- a/Projects/Shared/DesignSystem/Sources/Map/MapModel.swift
+++ b/Projects/Shared/DesignSystem/Sources/Map/MapModel.swift
@@ -1,0 +1,68 @@
+import UIKit
+
+// MARK: - MapCoordinate
+
+public struct MapCoordinate: Sendable, Equatable {
+    public let latitude: Double
+    public let longitude: Double
+
+    public init(latitude: Double, longitude: Double) {
+        self.latitude = latitude
+        self.longitude = longitude
+    }
+}
+
+// MARK: - MapRoute
+
+public struct MapRoute: Sendable, Equatable, Identifiable {
+    public let id: String
+    public let coordinates: [MapCoordinate]
+    public let lineColor: UIColor
+    public let lineWidth: UInt
+    public let strokeColor: UIColor
+    public let strokeWidth: UInt
+
+    public init(
+        id: String = UUID().uuidString,
+        coordinates: [MapCoordinate],
+        lineColor: UIColor = .systemBlue,
+        lineWidth: UInt = 4,
+        strokeColor: UIColor = .clear,
+        strokeWidth: UInt = 0
+    ) {
+        self.id = id
+        self.coordinates = coordinates
+        self.lineColor = lineColor
+        self.lineWidth = lineWidth
+        self.strokeColor = strokeColor
+        self.strokeWidth = strokeWidth
+    }
+}
+
+// MARK: - MapPin
+
+public struct MapPin: Sendable, Equatable, Identifiable {
+    public let id: String
+    public let coordinate: MapCoordinate
+    public let title: String
+    public let iconImage: UIImage?
+
+    public init(
+        id: String = UUID().uuidString,
+        coordinate: MapCoordinate,
+        title: String = "",
+        iconImage: UIImage? = nil
+    ) {
+        self.id = id
+        self.coordinate = coordinate
+        self.title = title
+        self.iconImage = iconImage
+    }
+
+    public static func == (lhs: MapPin, rhs: MapPin) -> Bool {
+        lhs.id == rhs.id
+            && lhs.coordinate == rhs.coordinate
+            && lhs.title == rhs.title
+            && lhs.iconImage === rhs.iconImage
+    }
+}

--- a/Projects/Shared/DesignSystemDemo/Derived/InfoPlists/DesignSystemDemo-Info.plist
+++ b/Projects/Shared/DesignSystemDemo/Derived/InfoPlists/DesignSystemDemo-Info.plist
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>KAKAO_APP_KEY</key>
+	<string>$(KAKAO_DEMO_APP_KEY)</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict/>
+	</dict>
+	<key>UILaunchScreen</key>
+	<dict/>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/Projects/Shared/DesignSystemDemo/Derived/Sources/TuistAssets+DesignSystemDemo.swift
+++ b/Projects/Shared/DesignSystemDemo/Derived/Sources/TuistAssets+DesignSystemDemo.swift
@@ -1,0 +1,93 @@
+// swiftlint:disable:this file_name
+// swiftlint:disable all
+// swift-format-ignore-file
+// swiftformat:disable all
+// Generated using tuist — https://github.com/tuist/tuist
+
+
+
+#if os(macOS)
+#if hasFeature(InternalImportsByDefault)
+public import AppKit
+#else
+import AppKit
+#endif
+#else
+#if hasFeature(InternalImportsByDefault)
+public import UIKit
+#else
+import UIKit
+#endif
+#endif
+
+#if canImport(SwiftUI)
+#if hasFeature(InternalImportsByDefault)
+public import SwiftUI
+#else
+import SwiftUI
+#endif
+#endif
+
+// MARK: - Asset Catalogs
+
+public enum DesignSystemDemoAsset: Sendable {
+  public static let accentColor = DesignSystemDemoColors(name: "AccentColor")
+}
+
+// MARK: - Implementation Details
+
+public final class DesignSystemDemoColors: Sendable {
+  public let name: String
+
+  #if os(macOS)
+  public typealias Color = NSColor
+  #elseif os(iOS) || os(tvOS) || os(watchOS) || os(visionOS)
+  public typealias Color = UIColor
+  #endif
+
+  @available(iOS 11.0, tvOS 11.0, watchOS 4.0, macOS 10.13, visionOS 1.0, *)
+  public var color: Color {
+    guard let color = Color(asset: self) else {
+      fatalError("Unable to load color asset named \(name).")
+    }
+    return color
+  }
+
+  #if canImport(SwiftUI)
+  @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, visionOS 1.0, *)
+  public var swiftUIColor: SwiftUI.Color {
+      return SwiftUI.Color(asset: self)
+  }
+  #endif
+
+  fileprivate init(name: String) {
+    self.name = name
+  }
+}
+
+public extension DesignSystemDemoColors.Color {
+  @available(iOS 11.0, tvOS 11.0, watchOS 4.0, macOS 10.13, visionOS 1.0, *)
+  convenience init?(asset: DesignSystemDemoColors) {
+    let bundle = Bundle.module
+    #if os(iOS) || os(tvOS) || os(visionOS)
+    self.init(named: asset.name, in: bundle, compatibleWith: nil)
+    #elseif os(macOS)
+    self.init(named: NSColor.Name(asset.name), bundle: bundle)
+    #elseif os(watchOS)
+    self.init(named: asset.name)
+    #endif
+  }
+}
+
+#if canImport(SwiftUI)
+@available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, visionOS 1.0, *)
+public extension SwiftUI.Color {
+  init(asset: DesignSystemDemoColors) {
+    let bundle = Bundle.module
+    self.init(asset.name, bundle: bundle)
+  }
+}
+#endif
+
+// swiftformat:enable all
+// swiftlint:enable all

--- a/Projects/Shared/DesignSystemDemo/Derived/Sources/TuistBundle+DesignSystemDemo.swift
+++ b/Projects/Shared/DesignSystemDemo/Derived/Sources/TuistBundle+DesignSystemDemo.swift
@@ -1,0 +1,25 @@
+// periphery:ignore:all
+// swiftlint:disable:this file_name
+// swiftlint:disable all
+// swift-format-ignore-file
+// swiftformat:disable all
+#if hasFeature(InternalImportsByDefault)
+public import Foundation
+#else
+import Foundation
+#endif
+// MARK: - Swift Bundle Accessor for Frameworks
+private class BundleFinder {}
+extension Foundation.Bundle {
+/// Since DesignSystemDemo is a application, the bundle for classes within this module can be used directly.
+    static let module = Bundle(for: BundleFinder.self)
+}
+// MARK: - Objective-C Bundle Accessor
+@objc
+public final class DesignSystemDemoResources: NSObject {
+@objc public class var bundle: Bundle {
+    return .module
+}
+}
+// swiftformat:enable all
+// swiftlint:enable all

--- a/Projects/Shared/DesignSystemDemo/DesignSystemDemo.xcodeproj/project.pbxproj
+++ b/Projects/Shared/DesignSystemDemo/DesignSystemDemo.xcodeproj/project.pbxproj
@@ -1,0 +1,482 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 55;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		035BCD5A56835C2B3865D447 /* DesignSystem_DesignSystem.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 8B796077B636509A4237DC3D /* DesignSystem_DesignSystem.bundle */; };
+		115465DC603822CD652B57EA /* KakaoMapsSDK-SPM_KakaoMapsSDK_SPM.bundle in Dependencies */ = {isa = PBXBuildFile; fileRef = 1E0E86780C5B875ABFE91E09 /* KakaoMapsSDK-SPM_KakaoMapsSDK_SPM.bundle */; };
+		1435ADA48F1C07F7028343F5 /* KakaoMapsSDK-SPM_KakaoMapsSDK_SPM.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 1E0E86780C5B875ABFE91E09 /* KakaoMapsSDK-SPM_KakaoMapsSDK_SPM.bundle */; };
+		1FE3FD7DDBD71188C2A117AA /* KakaoMapsSDK.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0DA458566F539C801214D46F /* KakaoMapsSDK.xcframework */; };
+		286F7BAB8D231FCE5E56DCD6 /* KakaoMapDemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8E270D7A56427D1864BA179 /* KakaoMapDemoView.swift */; };
+		402C3D92523A3402909A146D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 5680466674C29D9C46D14676 /* Assets.xcassets */; };
+		47E1F6BE196E5EEC5F4374E3 /* DesignSystemDemoApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = F22B80A87D0B50BAA28257FB /* DesignSystemDemoApp.swift */; };
+		4BF029C20F5DB84536C89902 /* KakaoMapsSDK.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 0DA458566F539C801214D46F /* KakaoMapsSDK.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		58A41C7A70ECC3C6FAB94906 /* DesignSystem.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8CA7D16128934CF79F35C043 /* DesignSystem.framework */; };
+		777368C462FC1F644B34B238 /* DesignSystemDemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02EB787DE6425AE27432301F /* DesignSystemDemoView.swift */; };
+		A1317F65B68E216CBFBFC9C4 /* KakaoMapsSDK_SPM.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 066C91E77805F1BE45DE2AA2 /* KakaoMapsSDK_SPM.framework */; };
+		AE9DF05BA9062FCB5FD39B76 /* TuistBundle+DesignSystemDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67424CC3105B3759E9767448 /* TuistBundle+DesignSystemDemo.swift */; };
+		C2EA3ADD18CDD7A882A566E8 /* DesignSystem_DesignSystem.bundle in Dependencies */ = {isa = PBXBuildFile; fileRef = 8B796077B636509A4237DC3D /* DesignSystem_DesignSystem.bundle */; };
+		F0468322113D9FE2E42198D4 /* TuistAssets+DesignSystemDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6DBA075684D648A28628AB9 /* TuistAssets+DesignSystemDemo.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		54DB24BC598B3A5C4895BF0E /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				4BF029C20F5DB84536C89902 /* KakaoMapsSDK.xcframework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B8009FADB766950D9216000B /* Dependencies */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 8;
+			dstSubfolderSpec = 16;
+			files = (
+				C2EA3ADD18CDD7A882A566E8 /* DesignSystem_DesignSystem.bundle in Dependencies */,
+				115465DC603822CD652B57EA /* KakaoMapsSDK-SPM_KakaoMapsSDK_SPM.bundle in Dependencies */,
+			);
+			name = Dependencies;
+			runOnlyForDeploymentPostprocessing = 1;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		02EB787DE6425AE27432301F /* DesignSystemDemoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignSystemDemoView.swift; sourceTree = "<group>"; };
+		066C91E77805F1BE45DE2AA2 /* KakaoMapsSDK_SPM.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = KakaoMapsSDK_SPM.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		0DA458566F539C801214D46F /* KakaoMapsSDK.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = KakaoMapsSDK.xcframework; path = "/Users/hyeji/Bangawo/Tuist/.build/checkouts/KakaoMapsSDK-SPM/BinaryFramework/KakaoMapsSDK.xcframework"; sourceTree = "<absolute>"; };
+		1E0E86780C5B875ABFE91E09 /* KakaoMapsSDK-SPM_KakaoMapsSDK_SPM.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "KakaoMapsSDK-SPM_KakaoMapsSDK_SPM.bundle"; sourceTree = BUILT_PRODUCTS_DIR; };
+		5680466674C29D9C46D14676 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		67424CC3105B3759E9767448 /* TuistBundle+DesignSystemDemo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TuistBundle+DesignSystemDemo.swift"; sourceTree = "<group>"; };
+		8B796077B636509A4237DC3D /* DesignSystem_DesignSystem.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DesignSystem_DesignSystem.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
+		8CA7D16128934CF79F35C043 /* DesignSystem.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DesignSystem.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		A6DBA075684D648A28628AB9 /* TuistAssets+DesignSystemDemo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TuistAssets+DesignSystemDemo.swift"; sourceTree = "<group>"; };
+		ADE76491A2EE495E1AC8B58D /* Dev.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Dev.xcconfig; sourceTree = "<group>"; };
+		B94F1F944F02890B322B768A /* DesignSystemDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DesignSystemDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		D92FA25C8AA1D8B287B16451 /* DesignSystemDemo-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "DesignSystemDemo-Info.plist"; sourceTree = "<group>"; };
+		EA455060E7D63C1CF8D0B2BB /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
+		F22B80A87D0B50BAA28257FB /* DesignSystemDemoApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignSystemDemoApp.swift; sourceTree = "<group>"; };
+		F8E270D7A56427D1864BA179 /* KakaoMapDemoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KakaoMapDemoView.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		E1EF584AAAC71F43E9159639 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				58A41C7A70ECC3C6FAB94906 /* DesignSystem.framework in Frameworks */,
+				A1317F65B68E216CBFBFC9C4 /* KakaoMapsSDK_SPM.framework in Frameworks */,
+				1FE3FD7DDBD71188C2A117AA /* KakaoMapsSDK.xcframework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		00378ABA3C099C610E9C1F77 /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				F22B80A87D0B50BAA28257FB /* DesignSystemDemoApp.swift */,
+				02EB787DE6425AE27432301F /* DesignSystemDemoView.swift */,
+				F8E270D7A56427D1864BA179 /* KakaoMapDemoView.swift */,
+			);
+			path = Sources;
+			sourceTree = "<group>";
+		};
+		1D01F8576E94CFBE743E3DFE /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				0DA458566F539C801214D46F /* KakaoMapsSDK.xcframework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		20538126FCBBD87411CE882F /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				A6DBA075684D648A28628AB9 /* TuistAssets+DesignSystemDemo.swift */,
+				67424CC3105B3759E9767448 /* TuistBundle+DesignSystemDemo.swift */,
+			);
+			path = Sources;
+			sourceTree = "<group>";
+		};
+		34C351DE522FD6E9A1024C8C = {
+			isa = PBXGroup;
+			children = (
+				9FE6E0C0387FEE5327A69E1D /* Products */,
+				CB1EB83E714EF850923E4431 /* Project */,
+				1D01F8576E94CFBE743E3DFE /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		5598DAD19A8643E6DA0EABB1 /* InfoPlists */ = {
+			isa = PBXGroup;
+			children = (
+				D92FA25C8AA1D8B287B16451 /* DesignSystemDemo-Info.plist */,
+			);
+			path = InfoPlists;
+			sourceTree = "<group>";
+		};
+		5BBEB4D6604E223763F85082 /* Config */ = {
+			isa = PBXGroup;
+			children = (
+				ADE76491A2EE495E1AC8B58D /* Dev.xcconfig */,
+				EA455060E7D63C1CF8D0B2BB /* Release.xcconfig */,
+			);
+			name = Config;
+			path = ../../../Config;
+			sourceTree = "<group>";
+		};
+		7B4BC8BD090A8F2E18483962 /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				5680466674C29D9C46D14676 /* Assets.xcassets */,
+			);
+			path = Resources;
+			sourceTree = "<group>";
+		};
+		7F49A1EAECED9086DFEC12B8 /* Derived */ = {
+			isa = PBXGroup;
+			children = (
+				5598DAD19A8643E6DA0EABB1 /* InfoPlists */,
+				20538126FCBBD87411CE882F /* Sources */,
+			);
+			path = Derived;
+			sourceTree = "<group>";
+		};
+		9FE6E0C0387FEE5327A69E1D /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				8B796077B636509A4237DC3D /* DesignSystem_DesignSystem.bundle */,
+				8CA7D16128934CF79F35C043 /* DesignSystem.framework */,
+				B94F1F944F02890B322B768A /* DesignSystemDemo.app */,
+				066C91E77805F1BE45DE2AA2 /* KakaoMapsSDK_SPM.framework */,
+				1E0E86780C5B875ABFE91E09 /* KakaoMapsSDK-SPM_KakaoMapsSDK_SPM.bundle */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		CB1EB83E714EF850923E4431 /* Project */ = {
+			isa = PBXGroup;
+			children = (
+				5BBEB4D6604E223763F85082 /* Config */,
+				7F49A1EAECED9086DFEC12B8 /* Derived */,
+				7B4BC8BD090A8F2E18483962 /* Resources */,
+				00378ABA3C099C610E9C1F77 /* Sources */,
+			);
+			name = Project;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		4F48062D8CAFAD935D848541 /* DesignSystemDemo */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 403A70FB5C57FD19D330D2D5 /* Build configuration list for PBXNativeTarget "DesignSystemDemo" */;
+			buildPhases = (
+				CB1274151334F4EFD36DF8A8 /* Sources */,
+				9C60472656C5AC3E76BF42CE /* Resources */,
+				E1EF584AAAC71F43E9159639 /* Frameworks */,
+				54DB24BC598B3A5C4895BF0E /* Embed Frameworks */,
+				B8009FADB766950D9216000B /* Dependencies */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = DesignSystemDemo;
+			packageProductDependencies = (
+			);
+			productName = DesignSystemDemo;
+			productReference = B94F1F944F02890B322B768A /* DesignSystemDemo.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		595278E4D4EE04825B65F837 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = YES;
+				TargetAttributes = {
+				};
+			};
+			buildConfigurationList = 070DFDBE6E3A2E0265BCDB80 /* Build configuration list for PBXProject "DesignSystemDemo" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				Base,
+				en,
+			);
+			mainGroup = 34C351DE522FD6E9A1024C8C;
+			productRefGroup = 9FE6E0C0387FEE5327A69E1D /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				4F48062D8CAFAD935D848541 /* DesignSystemDemo */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		9C60472656C5AC3E76BF42CE /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				402C3D92523A3402909A146D /* Assets.xcassets in Resources */,
+				035BCD5A56835C2B3865D447 /* DesignSystem_DesignSystem.bundle in Resources */,
+				1435ADA48F1C07F7028343F5 /* KakaoMapsSDK-SPM_KakaoMapsSDK_SPM.bundle in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		CB1274151334F4EFD36DF8A8 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F0468322113D9FE2E42198D4 /* TuistAssets+DesignSystemDemo.swift in Sources */,
+				AE9DF05BA9062FCB5FD39B76 /* TuistBundle+DesignSystemDemo.swift in Sources */,
+				47E1F6BE196E5EEC5F4374E3 /* DesignSystemDemoApp.swift in Sources */,
+				777368C462FC1F644B34B238 /* DesignSystemDemoView.swift in Sources */,
+				286F7BAB8D231FCE5E56DCD6 /* KakaoMapDemoView.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		453997631F0D7AA433DCF622 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				ENABLE_PREVIEWS = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../../../Tuist/.build/checkouts/KakaoMapsSDK-SPM/BinaryFramework",
+				);
+				INFOPLIST_FILE = "Derived/InfoPlists/DesignSystemDemo-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-L$(DT_TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.ddd-ios2.Bangawo.DesignSystemDemo";
+				PRODUCT_NAME = DesignSystemDemo;
+				SDKROOT = iphoneos;
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+					"$(inherited)",
+					DEBUG,
+				);
+				SWIFT_COMPILATION_MODE = singlefile;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TARGETED_DEVICE_FAMILY = 1;
+			};
+			name = Debug;
+		};
+		68FBDFCF126943C00401B8C7 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = EA455060E7D63C1CF8D0B2BB /* Release.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = "$(ARCHS_STANDARD)";
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 10;
+				DEAD_CODE_STRIPPING = YES;
+				DEBUG_INFORMATION_FORMAT = "DWARF with dSYM File";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MARKETING_VERSION = 1.0.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "-ObjC -all_load";
+				PRODUCT_NAME = DesignSystemDemo;
+				STRIP_STYLE = "non-global";
+				SWIFT_VERSION = 6.0;
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Release;
+		};
+		806F9E482D76121873F3E00F /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				ENABLE_PREVIEWS = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../../../Tuist/.build/checkouts/KakaoMapsSDK-SPM/BinaryFramework",
+				);
+				INFOPLIST_FILE = "Derived/InfoPlists/DesignSystemDemo-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-L$(DT_TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.ddd-ios2.Bangawo.DesignSystemDemo";
+				PRODUCT_NAME = DesignSystemDemo;
+				SDKROOT = iphoneos;
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				TARGETED_DEVICE_FAMILY = 1;
+			};
+			name = Release;
+		};
+		F39E7AE0B174D17D0CE7A0B4 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = ADE76491A2EE495E1AC8B58D /* Dev.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = "$(ARCHS_STANDARD)";
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 10;
+				DEAD_CODE_STRIPPING = YES;
+				DEBUG_INFORMATION_FORMAT = "DWARF with dSYM File";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MARKETING_VERSION = 1.0.0;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_LDFLAGS = "-ObjC -all_load";
+				PRODUCT_NAME = DesignSystemDemo;
+				STRIP_STYLE = "non-global";
+				SWIFT_VERSION = 6.0;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Debug;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		070DFDBE6E3A2E0265BCDB80 /* Build configuration list for PBXProject "DesignSystemDemo" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F39E7AE0B174D17D0CE7A0B4 /* Debug */,
+				68FBDFCF126943C00401B8C7 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		403A70FB5C57FD19D330D2D5 /* Build configuration list for PBXNativeTarget "DesignSystemDemo" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				453997631F0D7AA433DCF622 /* Debug */,
+				806F9E482D76121873F3E00F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 595278E4D4EE04825B65F837 /* Project object */;
+}

--- a/Projects/Shared/DesignSystemDemo/DesignSystemDemo.xcodeproj/xcshareddata/xcschemes/DesignSystemDemo.xcscheme
+++ b/Projects/Shared/DesignSystemDemo/DesignSystemDemo.xcodeproj/xcshareddata/xcschemes/DesignSystemDemo.xcscheme
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1010"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4F48062D8CAFAD935D848541"
+               BuildableName = "DesignSystemDemo.app"
+               BlueprintName = "DesignSystemDemo"
+               ReferencedContainer = "container:DesignSystemDemo.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      disableMainThreadChecker = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4F48062D8CAFAD935D848541"
+            BuildableName = "DesignSystemDemo.app"
+            BlueprintName = "DesignSystemDemo"
+            ReferencedContainer = "container:DesignSystemDemo.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4F48062D8CAFAD935D848541"
+            BuildableName = "DesignSystemDemo.app"
+            BlueprintName = "DesignSystemDemo"
+            ReferencedContainer = "container:DesignSystemDemo.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Projects/Shared/DesignSystemDemo/Project.swift
+++ b/Projects/Shared/DesignSystemDemo/Project.swift
@@ -1,0 +1,28 @@
+import Foundation
+import ProjectDescription
+import DependencyPlugin
+import ProjectTemplatePlugin
+import DependencyPackagePlugin
+
+let project = Project.makeModule(
+  name: "DesignSystemDemo",
+  bundleId: .appBundleID(name: ".DesignSystemDemo"),
+  product: .app,
+  settings: .appBaseSetting(appName: "DesignSystemDemo"),
+  dependencies: [
+    .Shared(implements: .DesignSystem),
+    .SPM.kakaoMapsSDK
+  ],
+  sources: ["Sources/**"],
+  resources: ["Resources/**"],
+  infoPlist: .extendingDefault(
+    with: [
+      "KAKAO_APP_KEY": .string("$(KAKAO_DEMO_APP_KEY)"),
+      "NSAppTransportSecurity": .dictionary([
+        "NSAllowsArbitraryLoads": .boolean(true)
+      ]),
+      "UILaunchScreen": .dictionary([:])
+    ]
+  ),
+  hasTests: false
+)

--- a/Projects/Shared/DesignSystemDemo/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Projects/Shared/DesignSystemDemo/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Projects/Shared/DesignSystemDemo/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Projects/Shared/DesignSystemDemo/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,53 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Projects/Shared/DesignSystemDemo/Resources/Assets.xcassets/Contents.json
+++ b/Projects/Shared/DesignSystemDemo/Resources/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Projects/Shared/DesignSystemDemo/Sources/DesignSystemDemoApp.swift
+++ b/Projects/Shared/DesignSystemDemo/Sources/DesignSystemDemoApp.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+@preconcurrency import KakaoMapsSDK
+
+@main
+struct DesignSystemDemoApp: App {
+    init() {
+        if let appKey = Bundle.main.infoDictionary?["KAKAO_APP_KEY"] as? String, !appKey.isEmpty {
+            print("[KakaoMap] App Key loaded: \(appKey.prefix(6))******")
+            SDKInitializer.InitSDK(appKey: appKey, phase: .real)
+        } else {
+            print("[KakaoMap] App Key not found in Info.plist")
+        }
+    }
+
+    var body: some Scene {
+        WindowGroup {
+            NavigationStack {
+                DesignSystemDemoView()
+            }
+        }
+    }
+}

--- a/Projects/Shared/DesignSystemDemo/Sources/DesignSystemDemoView.swift
+++ b/Projects/Shared/DesignSystemDemo/Sources/DesignSystemDemoView.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+
+enum DemoComponent: String, CaseIterable, Identifiable {
+    case kakaoMap = "KakaoMap"
+
+    var id: String { rawValue }
+}
+
+struct DesignSystemDemoView: View {
+    var body: some View {
+        List(DemoComponent.allCases) { component in
+            NavigationLink(component.rawValue, value: component)
+        }
+        .navigationTitle("DesignSystem")
+        .navigationDestination(for: DemoComponent.self) { component in
+            switch component {
+            case .kakaoMap:
+                KakaoMapDemoView()
+            }
+        }
+    }
+}

--- a/Projects/Shared/DesignSystemDemo/Sources/KakaoMapDemoView.swift
+++ b/Projects/Shared/DesignSystemDemo/Sources/KakaoMapDemoView.swift
@@ -1,0 +1,87 @@
+import SwiftUI
+import DesignSystem
+
+struct KakaoMapDemoView: View {
+    @State private var tappedPin: MapPin?
+
+    private let seoulCenter = MapCoordinate(latitude: 37.5665, longitude: 126.9780)
+
+    private let samplePins: [MapPin] = [
+        MapPin(
+            coordinate: MapCoordinate(latitude: 37.5665, longitude: 126.9780),
+            title: "서울시청"
+        ),
+        MapPin(
+            coordinate: MapCoordinate(latitude: 37.5512, longitude: 126.9882),
+            title: "남산타워"
+        ),
+        MapPin(
+            coordinate: MapCoordinate(latitude: 37.5796, longitude: 126.9770),
+            title: "경복궁"
+        ),
+    ]
+
+    private let sampleRoute: [MapRoute] = [
+        MapRoute(
+            coordinates: [
+                MapCoordinate(latitude: 37.5796, longitude: 126.9770),
+                MapCoordinate(latitude: 37.5735, longitude: 126.9790),
+                MapCoordinate(latitude: 37.5665, longitude: 126.9780),
+                MapCoordinate(latitude: 37.5512, longitude: 126.9882),
+            ],
+            lineColor: .systemBlue,
+            lineWidth: 5
+        ),
+    ]
+
+    var body: some View {
+        VStack(spacing: 0) {
+            KakaoMap(
+                routes: sampleRoute,
+                pins: samplePins,
+                initialCenter: seoulCenter,
+                initialZoomLevel: 14
+            )
+            .onPinTapped { pin in
+                tappedPin = pin
+            }
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+            .padding(16)
+
+            coordinateInfoSection
+                .padding(.horizontal, 16)
+                .padding(.bottom, 16)
+        }
+        .navigationTitle("KakaoMap")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private var coordinateInfoSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("좌표 정보")
+                .font(.headline)
+
+            if let pin = tappedPin {
+                HStack {
+                    Text(pin.title)
+                        .fontWeight(.medium)
+                    Spacer()
+                    Text("\(pin.coordinate.latitude, specifier: "%.4f"), \(pin.coordinate.longitude, specifier: "%.4f")")
+                        .foregroundStyle(.secondary)
+                        .font(.footnote.monospaced())
+                }
+            } else {
+                Text("핀을 탭하면 좌표가 표시됩니다")
+                    .foregroundStyle(.secondary)
+                    .font(.subheadline)
+            }
+
+            Text("중심: \(seoulCenter.latitude, specifier: "%.4f"), \(seoulCenter.longitude, specifier: "%.4f")")
+                .foregroundStyle(.tertiary)
+                .font(.caption.monospaced())
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color(.secondarySystemBackground), in: RoundedRectangle(cornerRadius: 12))
+    }
+}

--- a/Projects/Shared/Shared/Shared.xcodeproj/project.pbxproj
+++ b/Projects/Shared/Shared/Shared.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		0F7C51CBACDF5C4DA176E637 /* DesignSystem_DesignSystem.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 0202CA9E6AAAC0787B68E995 /* DesignSystem_DesignSystem.bundle */; };
 		79D754C55D2E38EF431F6C6E /* Utill.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C94F2606E7E958A55416DF32 /* Utill.framework */; };
+		8249191F76A1AF5E9D2FBFAC /* KakaoMapsSDK_SPM.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 63AC6E2683A30FF89D4075ED /* KakaoMapsSDK_SPM.framework */; };
+		AF12B8F816308E58FC0A6267 /* KakaoMapsSDK.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1A9C6E400A1D0C985EBAFF00 /* KakaoMapsSDK.xcframework */; };
 		BD78CC586EFA1C7CBC6F8B73 /* Base.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CE59A41CA35A26F7854C331 /* Base.swift */; };
 		C0E9ABCA7163C2A40175E0F9 /* DesignSystem.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4AE87645A97032776452E22F /* DesignSystem.framework */; };
 		F137F005EB97558E94BABB39 /* DesignSystem_DesignSystem.bundle in Dependencies */ = {isa = PBXBuildFile; fileRef = 0202CA9E6AAAC0787B68E995 /* DesignSystem_DesignSystem.bundle */; };
@@ -41,7 +43,9 @@
 		0202CA9E6AAAC0787B68E995 /* DesignSystem_DesignSystem.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DesignSystem_DesignSystem.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
 		080C58231FCEDC083F899294 /* Shared.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Shared.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		0CE59A41CA35A26F7854C331 /* Base.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Base.swift; sourceTree = "<group>"; };
+		1A9C6E400A1D0C985EBAFF00 /* KakaoMapsSDK.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = KakaoMapsSDK.xcframework; path = "/Users/hyeji/Bangawo/Tuist/.build/checkouts/KakaoMapsSDK-SPM/BinaryFramework/KakaoMapsSDK.xcframework"; sourceTree = "<absolute>"; };
 		4AE87645A97032776452E22F /* DesignSystem.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DesignSystem.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		63AC6E2683A30FF89D4075ED /* KakaoMapsSDK_SPM.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = KakaoMapsSDK_SPM.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C94F2606E7E958A55416DF32 /* Utill.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Utill.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D72BA6AE8B9AF02B56D8FC04 /* Shared-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "Shared-Info.plist"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -52,7 +56,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				C0E9ABCA7163C2A40175E0F9 /* DesignSystem.framework in Frameworks */,
+				8249191F76A1AF5E9D2FBFAC /* KakaoMapsSDK_SPM.framework in Frameworks */,
 				79D754C55D2E38EF431F6C6E /* Utill.framework in Frameworks */,
+				AF12B8F816308E58FC0A6267 /* KakaoMapsSDK.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -81,6 +87,7 @@
 			children = (
 				0202CA9E6AAAC0787B68E995 /* DesignSystem_DesignSystem.bundle */,
 				4AE87645A97032776452E22F /* DesignSystem.framework */,
+				63AC6E2683A30FF89D4075ED /* KakaoMapsSDK_SPM.framework */,
 				080C58231FCEDC083F899294 /* Shared.framework */,
 				C94F2606E7E958A55416DF32 /* Utill.framework */,
 			);
@@ -108,7 +115,16 @@
 			children = (
 				72723117B1BFA01E33CBB7A6 /* Products */,
 				6EC0B98B4A7FF03886AD270E /* Project */,
+				E7E2DC04443691192563DF03 /* Frameworks */,
 			);
+			sourceTree = "<group>";
+		};
+		E7E2DC04443691192563DF03 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				1A9C6E400A1D0C985EBAFF00 /* KakaoMapsSDK.xcframework */,
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -195,6 +211,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../../../Tuist/.build/checkouts/KakaoMapsSDK-SPM/BinaryFramework",
+				);
 				INFOPLIST_FILE = "Derived/InfoPlists/Shared-Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
@@ -232,6 +252,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../../../Tuist/.build/checkouts/KakaoMapsSDK-SPM/BinaryFramework",
+				);
 				INFOPLIST_FILE = "Derived/InfoPlists/Shared-Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 26.0;

--- a/Tuist/Package.resolved
+++ b/Tuist/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "81ef63373329edbbb0c00d54bf2b35e6c5bc11eb22cb5ad6b3e4340ccc473f52",
+  "originHash" : "7e7fb0a50d139eaf4c22a9769a462e7c4c5c35b5747bd4e09924dc0e5a5d6826",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -26,6 +26,15 @@
       "state" : {
         "revision" : "5928286acce13def418ec36d05a001a9641086f2",
         "version" : "1.0.3"
+      }
+    },
+    {
+      "identity" : "kakaomapssdk-spm",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kakao-mapsSDK/KakaoMapsSDK-SPM",
+      "state" : {
+        "revision" : "cc073a32729b7f545cca49f96d0b859fa3a0d5db",
+        "version" : "2.12.10"
       }
     },
     {

--- a/Tuist/Package.swift
+++ b/Tuist/Package.swift
@@ -13,7 +13,8 @@ let packageSettings = PackageSettings(
     "XCTestDynamicOverlay": .staticFramework,
     "Clocks": .staticFramework,
     "ConcurrencyExtras": .staticFramework,
-    "Sharing": .staticFramework
+    "Sharing": .staticFramework,
+    "KakaoMapsSDK-SPM": .staticFramework
   ]
 )
 #endif
@@ -23,6 +24,7 @@ let package = Package(
   dependencies: [
     .package(url: "https://github.com/pointfreeco/swift-composable-architecture", exact: "1.25.0"),
     .package(url: "https://github.com/Roy-wonji/AsyncMoya", from: "1.1.8"),
-    .package(url: "https://github.com/pointfreeco/swift-sharing", from: "1.0.0")
+    .package(url: "https://github.com/pointfreeco/swift-sharing", from: "1.0.0"),
+    .package(url: "https://github.com/kakao-mapsSDK/KakaoMapsSDK-SPM", from: "2.12.0")
   ]
 )


### PR DESCRIPTION
## Summary
- KakaoMapsSDK SPM 의존성 추가 및 앱 레벨 초기화 설정
- KakaoMap, KakaoMapRepresentable, MapModel 등 지도 디자인 시스템 컴포넌트 구현
- 가시성 라이프사이클 기반 엔진 상태 관리 (onAppear/onDisappear 시 엔진 활성화/비활성화)
- DesignSystemDemo 독립 데모앱 프로젝트 추가

## Demo
<!-- 데모앱 실행 영상을 첨부해주세요 -->
![화면 기록 2026-04-15 오전 1 10 41](https://github.com/user-attachments/assets/d74e48a0-bf32-4801-bda4-bc297f08f237)

## To Reviewer
KakaoMapSDK 특성상 KMViewContainer의 bounds가 확정되기 전에 `prepareEngine()`을 호출하면 렌더 서피스가 생성되지 않아 지도가 표시되지 않는 이슈가 있었습니다.

현재는 `isVisible` 바인딩 + `DispatchQueue.main.asyncAfter(deadline: .now() + 0.5)` 지연 초기화로 해결한 상태인데, 이 접근 방식에 대해 의견 부탁드립니다:
- 0.5초 고정 딜레이 대신 더 나은 타이밍 감지 방법이 있을지
- `ViewDidLayoutSubviews` 시점 활용이 더 적절할지
- 현재 방식으로 충분한지

## Test Plan
- [x] DesignSystemDemo 앱 빌드 및 실행 확인
- [x] KakaoMap 지도 정상 렌더링 확인
- [x] 핀/경로 오버레이 표시 확인
- [x] 화면 전환(탭 이동) 후 복귀 시 지도 재렌더링 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)