### PR TITLE
[CHORE] Gemini Code Review 인라인 코멘트 방식으로 개선

### DIFF
--- a/.github/workflows/gemini-code-review.yml
+++ b/.github/workflows/gemini-code-review.yml
@@ -1,0 +1,101 @@
+name: Gemini Code Review
+on:
+  pull_request:
+    branches:
+      - develop
+    types: [opened, synchronize]
+
+jobs:
+  code-review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install GoogleGenerativeAI
+        run: npm install @google/generative-ai
+
+      - name: Get PR Context and Filtered Git Diff
+        id: get_diff
+        run: |
+          git fetch origin "${{ github.event.pull_request.base.ref }}"
+          git fetch origin "${{ github.event.pull_request.head.ref }}"
+
+          git diff "origin/${{ github.event.pull_request.base.ref }}"..."origin/${{ github.event.pull_request.head.ref }}" -- "*.swift" > diff.txt
+
+          if [ ! -s diff.txt ]; then
+            echo "skip_review=true" >> $GITHUB_OUTPUT
+          else
+            echo "skip_review=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Run Gemini Review
+        if: steps.get_diff.outputs.skip_review == 'false'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require("fs");
+            const diff_output = fs.readFileSync("diff.txt", "utf8");
+
+            const pr_title = context.payload.pull_request.title;
+            const pr_body = context.payload.pull_request.body || "내용 없음";
+
+            const { GoogleGenerativeAI } = require("@google/generative-ai");
+            const genAI = new GoogleGenerativeAI("${{ secrets.GEMINI_API_KEY }}");
+            const model = genAI.getGenerativeModel({ model: "gemini-2.5-flash" });
+
+            const prompt = `You are a senior iOS software engineer performing a code review on a Swift project that uses TCA (The Composable Architecture) 1.25 + Clean Architecture multi-module structure.
+
+            [PR Context]
+            Title: ${pr_title}
+            Description: ${pr_body}
+
+            [Project Architecture]
+            - Stack: Swift 6, SwiftUI, TCA 1.25, Tuist 4 (multi-module)
+            - Architecture: TCA + Clean Architecture
+            - Module dependency: Presentation → Domain ← Data, Network is only referenced by Data
+            - Deployment target: iOS 26.0
+
+            [Review Criteria]
+            1. TCA Pattern: Verify @Reducer macro usage, @ObservableState, event-based Action naming (e.g., xxxButtonTapped, xxxResponse), proper Effect usage (.none for no side effects, .run for async), and no shared logic between actions.
+            2. Architecture: Check layer separation (Presentation/Domain/Data), dependency direction compliance, protocol-based abstractions at module boundaries.
+            3. SwiftUI: SubView should be separate structs (not @ViewBuilder functions), no View suffix in naming, use .frame(maxWidth/maxHeight: .infinity) instead of Spacer.
+            4. Code Quality: guard early return, final class by default, private access first, no force unwrap, line limit 120 chars.
+            5. Actionable Feedback: If improvements are needed, provide specific Swift code snippets using GitHub's \`\`\`suggestion syntax.
+
+            Ignore comments and formatting changes. Write in Korean using Markdown without intro/outro.
+
+            <git diff>
+            ${diff_output}
+            </git diff>`;
+
+            const result = await model.generateContent(prompt);
+            const text = result.response.text();
+            fs.writeFileSync("review_result.txt", text);
+
+      - name: Comment on Pull Request
+        if: steps.get_diff.outputs.skip_review == 'false'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require("fs");
+            if (fs.existsSync("review_result.txt")) {
+              const body = fs.readFileSync("review_result.txt", "utf8");
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                body: body
+              });
+            }

--- a/.github/workflows/gemini-code-review.yml
+++ b/.github/workflows/gemini-code-review.yml
@@ -40,22 +40,109 @@ jobs:
             echo "skip_review=false" >> $GITHUB_OUTPUT
           fi
 
+      - name: Parse Diff for Valid Lines and Annotate
+        if: steps.get_diff.outputs.skip_review == 'false'
+        uses: actions/github-script@v7
+        id: parse_diff
+        with:
+          script: |
+            const fs = require("fs");
+            const diff = fs.readFileSync("diff.txt", "utf8");
+
+            const validLines = {};
+            const lineContentMap = {};
+            const annotatedLines = [];
+
+            let currentFile = null;
+            let lineNum = 0;
+
+            for (const line of diff.split("\n")) {
+              if (line.startsWith("diff --git")) {
+                const match = line.match(/b\/(.+)$/);
+                if (match) currentFile = match[1];
+                annotatedLines.push(line);
+                continue;
+              }
+
+              if (line.startsWith("+++") || line.startsWith("---") || line.startsWith("index ")) {
+                annotatedLines.push(line);
+                continue;
+              }
+
+              if (line.startsWith("@@") && currentFile) {
+                const match = line.match(/@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@/);
+                if (match) lineNum = parseInt(match[1]);
+                annotatedLines.push(line);
+                continue;
+              }
+
+              if (!currentFile) {
+                annotatedLines.push(line);
+                continue;
+              }
+
+              if (line.startsWith("+") && !line.startsWith("+++")) {
+                // Added line: valid comment target
+                if (!validLines[currentFile]) validLines[currentFile] = new Set();
+                validLines[currentFile].add(lineNum);
+
+                if (!lineContentMap[currentFile]) lineContentMap[currentFile] = {};
+                lineContentMap[currentFile][lineNum] = line.substring(1).trim();
+
+                annotatedLines.push(`[LINE ${lineNum}] ${line}`);
+                lineNum++;
+              } else if (line.startsWith("-") && !line.startsWith("---")) {
+                // Deleted line: no line number increment
+                annotatedLines.push(`[DEL] ${line}`);
+              } else {
+                // Context line: increment but not valid
+                annotatedLines.push(`[CTX ${lineNum}] ${line}`);
+                lineNum++;
+              }
+            }
+
+            // Serialize validLines (Set -> Array)
+            const serializable = {};
+            for (const [file, lines] of Object.entries(validLines)) {
+              serializable[file] = [...lines].sort((a, b) => a - b);
+            }
+
+            fs.writeFileSync("valid_lines.json", JSON.stringify(serializable));
+            fs.writeFileSync("line_content_map.json", JSON.stringify(lineContentMap));
+            fs.writeFileSync("annotated_diff.txt", annotatedLines.join("\n"));
+
       - name: Run Gemini Review
         if: steps.get_diff.outputs.skip_review == 'false'
         uses: actions/github-script@v7
         with:
           script: |
             const fs = require("fs");
-            const diff_output = fs.readFileSync("diff.txt", "utf8");
+            const annotated_diff = fs.readFileSync("annotated_diff.txt", "utf8");
 
             const pr_title = context.payload.pull_request.title;
             const pr_body = context.payload.pull_request.body || "내용 없음";
 
             const { GoogleGenerativeAI } = require("@google/generative-ai");
             const genAI = new GoogleGenerativeAI("${{ secrets.GEMINI_API_KEY }}");
-            const model = genAI.getGenerativeModel({ model: "gemini-2.5-flash" });
+            const model = genAI.getGenerativeModel({
+              model: "gemini-2.5-flash",
+              generationConfig: {
+                responseMimeType: "application/json",
+              },
+            });
 
-            const prompt = `You are a senior iOS software engineer performing a code review on a Swift project that uses TCA (The Composable Architecture) 1.25 + Clean Architecture multi-module structure.
+            const prompt = `You are a senior iOS engineer performing a code review on a Swift 6 / SwiftUI / TCA 1.25 multi-module Clean Architecture project built with Tuist 4.
+
+            [Tone and Style Guidelines]
+            - Do NOT include unnecessary praise, greetings, or overly verbose explanations.
+            - Do NOT provide unsolicited CS insights (컴퓨터 과학적 통찰) or related interview questions.
+            - Provide concise, objective, and well-organized feedback suitable for immediate practical use.
+
+            CRITICAL LINE NUMBER RULES (MUST FOLLOW):
+            - Each diff line is annotated with [LINE N] for added lines or [CTX N] for context lines.
+            - You MUST only comment on [LINE N] lines (added/modified code). NEVER comment on [CTX] or [DEL] lines.
+            - Use the EXACT number N shown in the [LINE N] annotation. Do NOT compute line numbers yourself.
+            - The "code_snippet" field must contain the actual code from that [LINE N] line.
 
             [PR Context]
             Title: ${pr_title}
@@ -63,39 +150,171 @@ jobs:
 
             [Project Architecture]
             - Stack: Swift 6, SwiftUI, TCA 1.25, Tuist 4 (multi-module)
-            - Architecture: TCA + Clean Architecture
-            - Module dependency: Presentation → Domain ← Data, Network is only referenced by Data
-            - Deployment target: iOS 26.0
+            - Layer dependency: Presentation → Domain ← Data, Network is only referenced by Data
+            - Deployment target: iOS 26.0 (iPhone only)
+            - Source roots: Projects/App, Projects/Presentation, Projects/Domain/{Entity,UseCase,DomainInterface,DataInterface}, Projects/Data/{Model,Repository,API,Service}, Projects/Network/*, Projects/Shared/*
 
             [Review Criteria]
-            1. TCA Pattern: Verify @Reducer macro usage, @ObservableState, event-based Action naming (e.g., xxxButtonTapped, xxxResponse), proper Effect usage (.none for no side effects, .run for async), and no shared logic between actions.
-            2. Architecture: Check layer separation (Presentation/Domain/Data), dependency direction compliance, protocol-based abstractions at module boundaries.
-            3. SwiftUI: SubView should be separate structs (not @ViewBuilder functions), no View suffix in naming, use .frame(maxWidth/maxHeight: .infinity) instead of Spacer.
-            4. Code Quality: guard early return, final class by default, private access first, no force unwrap, line limit 120 chars.
-            5. Actionable Feedback: If improvements are needed, provide specific Swift code snippets using GitHub's \`\`\`suggestion syntax.
+            1. TCA Convention: Verify @Reducer + @ObservableState usage; Action naming describes events that occurred (e.g., xxxButtonTapped, xxxResponse), NOT intended effects (e.g., performLogin, loadData); Effect is .none when no side effect and .run for async work; shared logic lives in private methods, NOT shared Actions; Effect.run must NOT capture entire @ObservableState (extract needed values first); Reducer must NOT perform CPU-intensive work (offload to Effect); Store.scope must use stored property paths only (no computed transforms); Navigation uses @Reducer enum; transient UI state (hover, focus, animation) stays in SwiftUI @State, not TCA State.
+            2. Module Architecture: Respect Presentation → Domain ← Data dependency direction; Network is only imported by Data; module boundaries expose protocols (DomainInterface / DataInterface); DTO-to-Entity mapping stays in Data layer.
+            3. SwiftUI Convention: SubViews are structs (NOT @ViewBuilder functions); use @Binding when a SubView mutates parent @State; no "View" suffix in View names (unless clarity requires it); use .frame(maxWidth/maxHeight: .infinity) instead of Spacer() for simple expansion; required props via init, optional props via ViewModifier-style functions.
+            4. Swift Code Quality: guard early return with shorthand optional binding (guard let value else { ... }) followed by a blank line; final class by default; private first (avoid fileprivate unless required); never force unwrap; operator line break puts operator at the start of the next line; function params line-break with closing paren on its own line; ternary for simple return/assignment only, split on '?'; [weak self] + guard let self else { return } in closures; constant groups as private enum (Metric/Font/Constant), NOT struct; empty collection literals ([] / [:]); indent 4 spaces; 120-char line limit.
+            5. Actionable Feedback: When improvement is needed you MUST provide a concrete Swift fix using GitHub's \`\`\`suggestion block.
 
-            Ignore comments and formatting changes. Write in Korean using Markdown without intro/outro.
+            [Severity Prefix]
+            Each comment body MUST start with a severity tag on its own line, then a blank line, then the actual comment:
+            - 🔴 [P1] Critical: force-unwrap crash risk, retain cycles / memory leaks, heavy or blocking work inside a Reducer, main-thread blocking
+            - 🟠 [P2] Major: module dependency-direction violations (e.g., Domain importing Data), Effect.run capturing entire @ObservableState, sharing logic through Actions, Store.scope with computed property, serious concurrency or error-mapping issues
+            - 🟡 [P3] Minor: Action naming that describes intent/effect (performLogin, loadData, setRecords), SubView written as @ViewBuilder function, Swift API Design Guideline violations on public APIs, inefficient Effect composition
+            - 🔵 [P4] Readability: View-suffix naming, Spacer() misuse, missing final / private, guard / ternary / line-break style violations, constant groups declared as struct instead of enum
+            - ⚪ [P5] Nitpick: typos, whitespace, formatting
 
-            <git diff>
-            ${diff_output}
-            </git diff>`;
+            Format: "🔴 **[P1] Critical**\\n\\nActual comment content here..."
+
+            Ignore comments and formatting-only changes. Write all review comments in Korean using Markdown, without greetings or closings.
+
+            [Example]
+            Given this annotated diff:
+            \`\`\`
+            diff --git a/Projects/Presentation/Sources/Login/LoginFeature.swift b/Projects/Presentation/Sources/Login/LoginFeature.swift
+            @@ -20,4 +20,6 @@
+            [CTX 20]    enum Action {
+            [LINE 21] +      case performLogin
+            [LINE 22] +      case setRecords([Diary])
+            \`\`\`
+
+            Correct response:
+            {
+              "summary": "TCA Action 네이밍이 의도/효과 기반이라 발생한 사건으로 바꾸는 것이 좋습니다.",
+              "comments": [
+                {
+                  "path": "Projects/Presentation/Sources/Login/LoginFeature.swift",
+                  "line": 21,
+                  "code_snippet": "case performLogin",
+                  "body": "🟡 **[P3] Minor**\\n\\nTCA Action은 '발생한 사건'을 서술해야 합니다. 'performLogin'은 의도된 효과 표현이므로 버튼 탭 이벤트로 고쳐주세요.\\n\\n\\\`\\\`\\\`suggestion\\n      case loginButtonTapped\\n\\\`\\\`\\\`"
+                }
+              ]
+            }
+
+            Respond ONLY with a JSON object in this exact format:
+            {
+              "summary": "전체 리뷰 요약 (한국어, 마크다운)",
+              "comments": [
+                {
+                  "path": "file path relative to repo root (from the b/ prefix in diff)",
+                  "line": <exact N from [LINE N] annotation>,
+                  "code_snippet": "the actual code content from that line",
+                  "body": "🔴/🟠/🟡/🔵/⚪ **[P1~P5] Label**\\n\\n리뷰 코멘트 (한국어, 마크다운. 개선이 필요하면 \`\`\`suggestion 블록 포함)"
+                }
+              ]
+            }
+
+            If no issues are found, return {"summary": "...", "comments": []}.
+
+            <annotated_diff>
+            ${annotated_diff}
+            </annotated_diff>`;
 
             const result = await model.generateContent(prompt);
             const text = result.response.text();
-            fs.writeFileSync("review_result.txt", text);
+            fs.writeFileSync("review_result.json", text);
 
-      - name: Comment on Pull Request
+      - name: Post Inline Review Comments
         if: steps.get_diff.outputs.skip_review == 'false'
         uses: actions/github-script@v7
         with:
           script: |
             const fs = require("fs");
-            if (fs.existsSync("review_result.txt")) {
-              const body = fs.readFileSync("review_result.txt", "utf8");
+            const raw = fs.readFileSync("review_result.json", "utf8");
+            const validLinesMap = JSON.parse(fs.readFileSync("valid_lines.json", "utf8"));
+            const lineContentMap = JSON.parse(fs.readFileSync("line_content_map.json", "utf8"));
+
+            let review;
+            try {
+              review = JSON.parse(raw);
+            } catch (e) {
+              console.log("JSON parse failed, falling back to single comment");
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: context.payload.pull_request.number,
-                body: body
+                body: raw,
+              });
+              return;
+            }
+
+            // Snap to nearest valid line with content matching
+            function snapToValidLine(comment) {
+              const fileLines = validLinesMap[comment.path];
+              if (!fileLines || fileLines.length === 0) {
+                console.log(`Dropping comment: file not in diff - ${comment.path}`);
+                return null;
+              }
+
+              // 1. Exact match
+              if (fileLines.includes(comment.line)) return comment.line;
+
+              // 2. Content-based matching using code_snippet
+              const fileContent = lineContentMap[comment.path] || {};
+              if (comment.code_snippet) {
+                const snippet = comment.code_snippet.trim();
+                for (const validLine of fileLines) {
+                  const content = fileContent[validLine] || "";
+                  if (content.includes(snippet) || snippet.includes(content)) {
+                    console.log(`Content-matched comment from line ${comment.line} to ${validLine} for ${comment.path}`);
+                    return validLine;
+                  }
+                }
+              }
+
+              // 3. Nearest valid line within ±5 lines
+              const THRESHOLD = 5;
+              let bestLine = null;
+              let bestDist = THRESHOLD + 1;
+              for (const validLine of fileLines) {
+                const dist = Math.abs(validLine - comment.line);
+                if (dist < bestDist) {
+                  bestDist = dist;
+                  bestLine = validLine;
+                }
+              }
+
+              if (bestLine !== null) {
+                console.log(`Snapped comment from line ${comment.line} to ${bestLine} (dist=${bestDist}) for ${comment.path}`);
+                return bestLine;
+              }
+
+              console.log(`Dropping comment: no valid line within ±${THRESHOLD} of line ${comment.line} for ${comment.path}`);
+              return null;
+            }
+
+            const reviewComments = (review.comments || [])
+              .map((c) => {
+                const snappedLine = snapToValidLine(c);
+                if (snappedLine === null) return null;
+                return {
+                  path: c.path,
+                  line: snappedLine,
+                  side: "RIGHT",
+                  body: c.body,
+                };
+              })
+              .filter(Boolean);
+
+            if (reviewComments.length > 0) {
+              await github.rest.pulls.createReview({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.payload.pull_request.number,
+                event: "COMMENT",
+                body: review.summary || "",
+                comments: reviewComments,
+              });
+            } else if (review.summary) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                body: review.summary,
               });
             }


### PR DESCRIPTION
## Summary
- 변경된 `*.swift` diff를 라인 단위로 파싱해 `[LINE N]` / `[CTX N]` / `[DEL]` 마커로 어노테이션 후 Gemini에게 전달
- Gemini 응답을 `responseMimeType: application/json`으로 강제해 `summary` + `comments[]`(path/line/code_snippet/body) 구조로 수신
- `valid_lines.json` + `line_content_map.json` 기반 스냅 로직(정확 매치 → code_snippet 매치 → ±5 라인 근접) 추가, 유효 라인에만 코멘트 게시
- PR 하단 단일 이슈 코멘트 대신 `pulls.createReview`로 **인라인 리뷰 코멘트** 방식으로 전환
- 프롬프트를 Swift 6 / SwiftUI / TCA 1.25 / Tuist 4 멀티모듈 Clean Architecture 스택에 맞게 전면 재작성 (모듈 의존성 방향, Action 네이밍, `Effect.run` 캡처, `Store.scope`, SubView 규칙, guard/final/private 등)
- P1~P5 심각도 태그 도입: Reducer heavy work·force unwrap은 P1, 의존성 역행·`@ObservableState` 전체 캡처는 P2, Action 네이밍 위반은 P3, View suffix·Spacer 남용은 P4, 오타는 P5

## Review Example
실제 워크플로 실행 시 PR의 해당 코드 라인에 아래와 같은 인라인 코멘트가 달린다.

````markdown
🟡 **[P3] Minor**

TCA Action은 '발생한 사건'을 서술해야 합니다. 'performLogin'은 의도된 효과 표현이므로 버튼 탭 이벤트로 고쳐주세요.

```suggestion
      case loginButtonTapped
```
````

````markdown
🟠 **[P2] Major**

`Effect.run` 클로저가 `state` 전체를 캡처하면 `@ObservableState`의 registrar가 메인 액터 밖으로 나가 런타임 이슈가 발생할 수 있습니다. 필요한 값만 추출 후 캡처해주세요.

```suggestion
    case .saveButtonTapped:
      let information = state.information
      return .run { send in
        await send(.delegate(.saved(information)))
      }
```
````

## Test plan
- [ ] `.swift` 변경을 포함한 드래프트 PR을 `develop` 대상으로 띄워 워크플로가 성공하는지 확인
- [ ] 각 지적이 PR 하단 단일 코멘트가 아닌 **해당 라인 인라인 코멘트**로 붙는지 확인
- [ ] 코멘트 첫 줄이 🔴/🟠/🟡/🔵/⚪ 심각도 태그로 시작하는지 확인
- [ ] `performLogin` 같은 의도 기반 Action 네이밍을 의도적으로 심었을 때 P3로 지적되는지 확인
- [ ] `.swift` 변경이 없는 PR에서는 `skip_review=true`로 Gemini 호출이 생략되는지 확인

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)