### PR TITLE
[FEAT] 애플로그인 구현

### DIFF
--- a/Plugins/DependencyPackagePlugin/Plugin.swift
+++ b/Plugins/DependencyPackagePlugin/Plugin.swift
@@ -2,8 +2,6 @@
 //  Plugin.swift
 //  Plugins
 //
-//  Created by DDD-iOS2 on 4/7/26.
-//
 
 import ProjectDescription
 

--- a/Plugins/DependencyPackagePlugin/ProjectDescriptionHelpers/DependencyPackage/Extension+TargetDependency.swift
+++ b/Plugins/DependencyPackagePlugin/ProjectDescriptionHelpers/DependencyPackage/Extension+TargetDependency.swift
@@ -2,8 +2,6 @@
 //  Extension+TargetDependency.swift
 //  Plugins
 //
-//  Created by DDD-iOS2 on 4/7/26.
-//
 
 import ProjectDescription
 

--- a/Plugins/DependencyPackagePlugin/ProjectDescriptionHelpers/DependencyPackage/Extension+TargetDependencySPM.swift
+++ b/Plugins/DependencyPackagePlugin/ProjectDescriptionHelpers/DependencyPackage/Extension+TargetDependencySPM.swift
@@ -2,8 +2,6 @@
 //  Extension+TargetDependencySPM.swift
 //  DependencyPackagePlugin
 //
-//  Created by DDD-iOS2 on 4/7/26.
-//
 
 import ProjectDescription
 

--- a/Plugins/DependencyPlugin/Plugin.swift
+++ b/Plugins/DependencyPlugin/Plugin.swift
@@ -2,8 +2,6 @@
 //  Plugin.swift
 //  Plugins
 //
-//  Created by DDD-iOS2 on 4/7/26.
-//
 
 import ProjectDescription
 

--- a/Plugins/DependencyPlugin/ProjectDescriptionHelpers/TargetDependency+Module/Modules.swift
+++ b/Plugins/DependencyPlugin/ProjectDescriptionHelpers/TargetDependency+Module/Modules.swift
@@ -2,8 +2,6 @@
 //  Modules.swift
 //  Plugins
 //
-//  Created by DDD-iOS2 on 4/7/26.
-//
 
 import Foundation
 import ProjectDescription

--- a/Plugins/DependencyPlugin/ProjectDescriptionHelpers/TargetDependency+Module/Path+Modules.swift
+++ b/Plugins/DependencyPlugin/ProjectDescriptionHelpers/TargetDependency+Module/Path+Modules.swift
@@ -2,8 +2,6 @@
 //  Path+Modules.swift
 //  Plugins
 //
-//  Created by DDD-iOS2 on 4/7/26.
-//
 
 import Foundation
 import ProjectDescription

--- a/Plugins/DependencyPlugin/ProjectDescriptionHelpers/TargetDependency+Module/TargetDependency+Modules.swift
+++ b/Plugins/DependencyPlugin/ProjectDescriptionHelpers/TargetDependency+Module/TargetDependency+Modules.swift
@@ -2,8 +2,6 @@
 //  TargetDependency+Modules.swift
 //  Plugins
 //
-//  Created by DDD-iOS2 on 4/7/26.
-//
 
 import Foundation
 import ProjectDescription

--- a/Plugins/ProjectTemplatePlugin/ProjectDescriptionHelpers/Configruation/ConfigurationEnvironment.swift
+++ b/Plugins/ProjectTemplatePlugin/ProjectDescriptionHelpers/Configruation/ConfigurationEnvironment.swift
@@ -2,8 +2,6 @@
 //  ConfigurationEnvironment.swift
 //  DependencyPackagePlugin
 //
-//  Created by DDD-iOS2 on 4/7/26.
-//
 
 import Foundation
 import ProjectDescription

--- a/Plugins/ProjectTemplatePlugin/ProjectDescriptionHelpers/Configruation/Extension+Configuration.swift
+++ b/Plugins/ProjectTemplatePlugin/ProjectDescriptionHelpers/Configruation/Extension+Configuration.swift
@@ -2,8 +2,6 @@
 //  Extension+Configuration.swift
 //  DependencyPackagePlugin
 //
-//  Created by DDD-iOS2 on 4/7/26.
-//
 
 import Foundation
 import ProjectDescription

--- a/Plugins/ProjectTemplatePlugin/ProjectDescriptionHelpers/Project+Templete/Extension+String.swift
+++ b/Plugins/ProjectTemplatePlugin/ProjectDescriptionHelpers/Project+Templete/Extension+String.swift
@@ -2,8 +2,6 @@
 //  Extension+String.swift
 //  MyPlugin
 //
-//  Created by DDD-iOS2 on 4/7/26.
-//
 
 import Foundation
 import ProjectDescription

--- a/Plugins/ProjectTemplatePlugin/ProjectDescriptionHelpers/Project+Templete/Project+Enviorment.swift
+++ b/Plugins/ProjectTemplatePlugin/ProjectDescriptionHelpers/Project+Templete/Project+Enviorment.swift
@@ -2,8 +2,6 @@
 //  Project+Environment.swift
 //  MyPlugin
 //
-//  Created by DDD-iOS2 on 4/7/26.
-//
 
 import Foundation
 import ProjectDescription

--- a/Plugins/ProjectTemplatePlugin/ProjectDescriptionHelpers/Project+Templete/Project+Template.swift
+++ b/Plugins/ProjectTemplatePlugin/ProjectDescriptionHelpers/Project+Templete/Project+Template.swift
@@ -2,8 +2,6 @@
 //  Project+Template.swift
 //  MyPlugin
 //
-//  Created by DDD-iOS2 on 4/7/26.
-//
 
 import ProjectDescription
 

--- a/Plugins/ProjectTemplatePlugin/ProjectDescriptionHelpers/Project+Templete/ProjectConfig.swift
+++ b/Plugins/ProjectTemplatePlugin/ProjectDescriptionHelpers/Project+Templete/ProjectConfig.swift
@@ -2,8 +2,6 @@
 //  ProjectConfig.swift
 //  MultiModuleTemplate
 //
-//  Created by DDD-iOS2 on 4/7/26.
-//
 
 import Foundation
 import ProjectDescription

--- a/Plugins/ProjectTemplatePlugin/ProjectDescriptionHelpers/Project+Templete/ResourceFileElements+Templete.swift
+++ b/Plugins/ProjectTemplatePlugin/ProjectDescriptionHelpers/Project+Templete/ResourceFileElements+Templete.swift
@@ -2,8 +2,6 @@
 //  ResourceFileElements+Templete.swift
 //  MyPlugin
 //
-//  Created by DDD-iOS2 on 4/7/26.
-//
 
 import Foundation
 import ProjectDescription

--- a/Plugins/ProjectTemplatePlugin/ProjectDescriptionHelpers/Project+Templete/SourceFilesList+Template.swift
+++ b/Plugins/ProjectTemplatePlugin/ProjectDescriptionHelpers/Project+Templete/SourceFilesList+Template.swift
@@ -2,8 +2,6 @@
 //  SourceFilesList+Template.swift
 //  MyPlugin
 //
-//  Created by DDD-iOS2 on 4/7/26.
-//
 
 import Foundation
 import ProjectDescription

--- a/Plugins/ProjectTemplatePlugin/ProjectDescriptionHelpers/Script/Extension+Script.swift
+++ b/Plugins/ProjectTemplatePlugin/ProjectDescriptionHelpers/Script/Extension+Script.swift
@@ -2,8 +2,6 @@
 //  Extension+Script.swift
 //  MyPlugin
 //
-//  Created by DDD-iOS2 on 4/7/26.
-//
 
 import Foundation
 import ProjectDescription

--- a/Plugins/ProjectTemplatePlugin/ProjectDescriptionHelpers/Script/Scripts.swift
+++ b/Plugins/ProjectTemplatePlugin/ProjectDescriptionHelpers/Script/Scripts.swift
@@ -2,8 +2,6 @@
 //  Scripts.swift
 //  MyPlugin
 //
-//  Created by DDD-iOS2 on 4/7/26.
-//
 
 import Foundation
 import ProjectDescription

--- a/Plugins/ProjectTemplatePlugin/ProjectDescriptionHelpers/Setting/Project+Settings.swift
+++ b/Plugins/ProjectTemplatePlugin/ProjectDescriptionHelpers/Setting/Project+Settings.swift
@@ -2,8 +2,6 @@
 //  Project+Settings.swift
 //  MyPlugin
 //
-//  Created by DDD-iOS2 on 4/7/26.
-//
 
 import Foundation
 import ProjectDescription

--- a/Plugins/ProjectTemplatePlugin/ProjectDescriptionHelpers/Setting/SettingDictionary.swift
+++ b/Plugins/ProjectTemplatePlugin/ProjectDescriptionHelpers/Setting/SettingDictionary.swift
@@ -2,8 +2,6 @@
 //  SettingDictionary.swift
 //  ProjectTemplatePlugin
 //
-//  Created by DDD-iOS2 on 4/7/26.
-//
 
 import Foundation
 import ProjectDescription

--- a/Plugins/ProjectTemplatePlugin/ProjectDescriptionHelpers/infoPlist/InfoPlistDictionary.swift
+++ b/Plugins/ProjectTemplatePlugin/ProjectDescriptionHelpers/infoPlist/InfoPlistDictionary.swift
@@ -2,8 +2,6 @@
 //  InfoPlistDictionary.swift
 //  Plugins
 //
-//  Created by DDD-iOS2 on 4/7/26.
-//
 
 import Foundation
 import ProjectDescription

--- a/Plugins/ProjectTemplatePlugin/ProjectDescriptionHelpers/infoPlist/Project+InfoPlist.swift
+++ b/Plugins/ProjectTemplatePlugin/ProjectDescriptionHelpers/infoPlist/Project+InfoPlist.swift
@@ -2,8 +2,6 @@
 //  Project+InfoPlist.swift
 //  Plugins
 //
-//  Created by DDD-iOS2 on 4/7/26.
-//
 
 import Foundation
 import ProjectDescription

--- a/Projects/App/Sources/Application/BangawoApp.swift
+++ b/Projects/App/Sources/Application/BangawoApp.swift
@@ -21,7 +21,7 @@ struct BangawoApp: App {
 
         prepareDependencies {
             $0.searchStationsClient = SearchStationsFactory.makeClient()
-            $0.socialAuthClient = AuthFactory.makeSocialAuthClient()
+            $0.socialAuthClient = AuthFactory.makeClient()
         }
 
         initializeNaverLoginSDK()

--- a/Projects/App/Sources/Factory/AuthFactory.swift
+++ b/Projects/App/Sources/Factory/AuthFactory.swift
@@ -2,8 +2,6 @@
 //  AuthFactory.swift
 //  Bangawo
 //
-//  Created by DDD-iOS2 on 5/5/26.
-//
 
 import CoreDependencies
 import DataUseCase
@@ -11,12 +9,13 @@ import Repository
 import Service
 
 enum AuthFactory {
-    static func makeSocialAuthClient() -> SocialAuthClient {
+    static func makeClient() -> SocialAuthClient {
         let repository = AuthRepositoryImpl()
         let useCase = SignInWithSocialUseCaseImpl(
             repository: repository,
             kakaoLoginService: KakaoLoginService(),
-            naverLoginService: NaverLoginService()
+            naverLoginService: NaverLoginService(),
+            appleLoginService: AppleLoginService()
         )
 
         return .live(useCase: useCase)

--- a/Projects/App/Tests/Sources/BangawoTests.swift
+++ b/Projects/App/Tests/Sources/BangawoTests.swift
@@ -2,8 +2,6 @@
 //  BangawoTests.swift
 //  BangawoTests
 //
-//  Created by TuistTool.
-//
 
 import XCTest
 

--- a/Projects/Core/CoreDependencies/Sources/Auth/SocialAuthClient.swift
+++ b/Projects/Core/CoreDependencies/Sources/Auth/SocialAuthClient.swift
@@ -2,8 +2,6 @@
 //  SocialAuthClient.swift
 //  CoreDependencies
 //
-//  Created by DDD-iOS2 on 5/4/26.
-//
 
 import ComposableArchitecture
 import DomainInterface

--- a/Projects/Core/CoreDependencies/Sources/Base.swift
+++ b/Projects/Core/CoreDependencies/Sources/Base.swift
@@ -1,6 +1,0 @@
-//
-//  Base.swift
-//  CoreDependencies
-//
-
-import Foundation

--- a/Projects/Data/API/APITests/Sources/Test.swift
+++ b/Projects/Data/API/APITests/Sources/Test.swift
@@ -2,7 +2,6 @@
 //  base.swift
 //  DDDAttendance
 //
-//  Created by DDD-iOS2 on 4/7/26.
 //  Copyright © 2025 DDD , Ltd. All rights reserved.
 //
 

--- a/Projects/Data/API/Sources/AuthEndPoint.swift
+++ b/Projects/Data/API/Sources/AuthEndPoint.swift
@@ -2,9 +2,6 @@
 //  AuthEndPoint.swift
 //  API
 //
-//  Created by DDD-iOS2 on 4/28/26.
-//  Copyright (c) 2025 DDD, Ltd., All rights reserved.
-//
 
 import Foundation
 import Alamofire

--- a/Projects/Data/DataUseCase/Sources/Auth/SignInWithSocialUseCaseImpl.swift
+++ b/Projects/Data/DataUseCase/Sources/Auth/SignInWithSocialUseCaseImpl.swift
@@ -2,8 +2,6 @@
 //  SignInWithSocialUseCaseImpl.swift
 //  DataUseCase
 //
-//  Created by DDD-iOS2 on 5/4/26.
-//
 
 import DataInterface
 import DomainInterface
@@ -16,15 +14,18 @@ public final class SignInWithSocialUseCaseImpl: SignInWithSocialUseCase {
     private let repository: AuthRepositoryProtocol
     private let kakaoLoginService: KakaoLoginServiceInterface
     private let naverLoginService: NaverLoginServiceInterface
+    private let appleLoginService: AppleLoginServiceInterface
 
     public init(
         repository: AuthRepositoryProtocol,
         kakaoLoginService: KakaoLoginServiceInterface,
-        naverLoginService: NaverLoginServiceInterface
+        naverLoginService: NaverLoginServiceInterface,
+        appleLoginService: AppleLoginServiceInterface,
     ) {
         self.repository = repository
         self.kakaoLoginService = kakaoLoginService
         self.naverLoginService = naverLoginService
+        self.appleLoginService = appleLoginService
     }
 
     public func execute(provider: SocialAuthProvider) async throws -> LoginResult {
@@ -45,8 +46,11 @@ public final class SignInWithSocialUseCaseImpl: SignInWithSocialUseCase {
                 providerToken: socialToken.accessToken
             )
 
-        case .apple: // TODO: 구현 필요
-            throw SocialAuthClientError.notImplemented(provider)
+        case .apple:
+            let socialToken = try await appleLoginService.login()
+            Log.debug("🔑 appleSocialToken: \(socialToken)")
+            return try await signInWithServer(provider: provider, providerToken: socialToken.accessToken
+            )
         }
     }
 }

--- a/Projects/Data/DataUseCase/Tests/Sources/DataUseCaseTests.swift
+++ b/Projects/Data/DataUseCase/Tests/Sources/DataUseCaseTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import DataUseCase
+
+final class DataUseCaseTests: XCTestCase {
+    func testDataUseCaseModuleLoads() {
+        XCTAssertTrue(true)
+    }
+}

--- a/Projects/Data/Model/ModelTests/Sources/Test.swift
+++ b/Projects/Data/Model/ModelTests/Sources/Test.swift
@@ -2,7 +2,6 @@
 //  base.swift
 //  DDDAttendance
 //
-//  Created by DDD-iOS2 on 4/7/26.
 //  Copyright © 2025 DDD , Ltd. All rights reserved.
 //
 

--- a/Projects/Data/Model/Sources/AuthDTO.swift
+++ b/Projects/Data/Model/Sources/AuthDTO.swift
@@ -2,9 +2,6 @@
 //  AuthDTO.swift
 //  Model
 //
-//  Created by DDD-iOS2 on 4/28/26.
-//  Copyright (c) 2025 DDD, Ltd., All rights reserved.
-//
 
 import Foundation
 import Entity

--- a/Projects/Data/Model/Sources/BaseResponse.swift
+++ b/Projects/Data/Model/Sources/BaseResponse.swift
@@ -2,7 +2,6 @@
 //  BaseResponse.swift
 //  Model
 //
-//  Created by DDD-iOS2 on 4/13/26.
 //  Copyright © 2025 DDD, Ltd., All rights reserved.
 //
 

--- a/Projects/Data/Repository/Sources/AuthRepositoryImpl.swift
+++ b/Projects/Data/Repository/Sources/AuthRepositoryImpl.swift
@@ -2,9 +2,6 @@
 //  AuthRepositoryImpl.swift
 //  Repository
 //
-//  Created by DDD-iOS2 on 4/28/26.
-//  Copyright (c) 2025 DDD, Ltd., All rights reserved.
-//
 
 import Foundation
 import Networking

--- a/Projects/Data/Repository/Sources/Base.swift
+++ b/Projects/Data/Repository/Sources/Base.swift
@@ -2,7 +2,6 @@
 //  base.swift
 //  DDDAttendance.
 //
-//  Created by DDD-iOS2 on 4/7/26.
 //  Copyright © 2025 DDD , Ltd., All rights reserved.
 //
 

--- a/Projects/Data/Repository/Tests/Sources/Test.swift
+++ b/Projects/Data/Repository/Tests/Sources/Test.swift
@@ -2,7 +2,6 @@
 //  base.swift
 //  DDDAttendance
 //
-//  Created by DDD-iOS2 on 4/7/26.
 //  Copyright © 2025 DDD , Ltd. All rights reserved.
 //
 

--- a/Projects/Data/Service/ServiceTests/Sources/Test.swift
+++ b/Projects/Data/Service/ServiceTests/Sources/Test.swift
@@ -2,7 +2,6 @@
 //  base.swift
 //  DDDAttendance
 //
-//  Created by DDD-iOS2 on 4/7/26.
 //  Copyright © 2025 DDD , Ltd. All rights reserved.
 //
 

--- a/Projects/Data/Service/Sources/Auth/AppleLoginService.swift
+++ b/Projects/Data/Service/Sources/Auth/AppleLoginService.swift
@@ -1,0 +1,116 @@
+//
+//  AppleLoginService.swift
+//  Service
+//
+import AuthenticationServices
+import DomainInterface
+import Entity
+import UIKit
+import Utill
+
+/// Apple 로그인 SDK를 앱의 공통 소셜 로그인 토큰 형태로 변환하는 서비스입니다.
+///
+/// Presentation 계층이 `AuthenticationServices`에 직접 의존하지 않도록
+/// Apple 인증 요청, delegate callback 처리, token 추출을 Service 계층 안에 숨깁니다.
+public protocol AppleLoginServiceInterface: Sendable {
+    @MainActor
+    func login() async throws -> SocialAuthToken
+}
+
+/// `ASAuthorizationController`의 delegate 기반 API를 async/await 형태로 감싼 구현체입니다.
+///
+/// Apple 로그인 UI는 UIKit window 위에 표시되어야 하므로 MainActor에서 동작합니다.
+
+public final class AppleLoginService: NSObject, AppleLoginServiceInterface, @unchecked Sendable {
+    /// Apple 로그인 결과를 `async` 호출 지점으로 돌려주기 위해 보관하는 continuation입니다.
+    /// 성공/실패 callback을 받은 뒤 반드시 resume하고 nil로 정리해야 합니다.
+    private var continuation: CheckedContinuation<SocialAuthToken, Error>?
+
+    public override init() {}
+    @MainActor
+    public func login() async throws -> SocialAuthToken {
+        // 사용자가 버튼을 빠르게 여러 번 누르더라도 Apple 인증 요청이 중복 실행되지 않도록 방어합니다.
+        guard continuation == nil else {
+            throw SocialAuthClientError.underlying("🍏 이미 Apple 로그인이 진행 중입니다.")
+        }
+
+        return try await withCheckedThrowingContinuation { continuation in
+            self.continuation = continuation
+
+            // Apple ID 인증 요청을 생성하고, 최초 로그인 시 이름/이메일 제공 동의를 요청합니다.
+            let provider = ASAuthorizationAppleIDProvider()
+            let request = provider.createRequest()
+            request.requestedScopes = [.fullName, .email]
+
+            // ASAuthorizationController는 delegate callback으로 결과를 전달하므로 self를 delegate로 연결합니다.
+            let controller = ASAuthorizationController(authorizationRequests: [request])
+            controller.delegate = self
+            controller.presentationContextProvider = self
+            controller.performRequests()
+        }
+    }
+}
+
+extension AppleLoginService: ASAuthorizationControllerPresentationContextProviding {
+    public func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
+        // Apple 로그인 sheet를 표시할 기준 window를 반환합니다.
+        // iOS 26부터 빈 UIWindow() 생성이 deprecated라서 현재 key window를 반드시 찾아 사용합니다.
+        guard let window = UIApplication.shared.connectedScenes
+            .compactMap({ $0 as? UIWindowScene })
+            .flatMap(\.windows)
+            .first(where: \.isKeyWindow)
+        else {
+            preconditionFailure("❌ Apple 로그인 표시를 위한 key window를 찾을 수 없습니다.")
+        }
+
+        return window
+    }
+}
+
+extension AppleLoginService: ASAuthorizationControllerDelegate {
+    public func authorizationController(
+        controller: ASAuthorizationController,
+        didCompleteWithAuthorization authorization: ASAuthorization
+    ) {
+        // Apple ID 인증 결과만 처리합니다. 다른 credential 타입이면 서버 검증에 사용할 토큰을 만들 수 없습니다.
+        guard let credential = authorization.credential as? ASAuthorizationAppleIDCredential else {
+            resume(throwing: SocialAuthClientError.missingToken(.apple))
+            return
+        }
+
+        // identityToken은 Apple이 서명한 JWT입니다.
+        // 서버는 이 값을 검증해 사용자의 Apple 계정 식별자를 신뢰할 수 있습니다.
+        guard let identityTokenData = credential.identityToken,
+              let identityToken = String(data: identityTokenData, encoding: .utf8) else {
+            resume(throwing: SocialAuthClientError.missingToken(.apple))
+            return
+        }
+
+        // TODO: 서버 애플 로그인 방식 확정 후 providerToken으로 identityToken을 보낼지 authorizationCode를 보낼지 결정합니다.
+        resume(returning: SocialAuthToken(accessToken: identityToken, refreshToken: nil))
+    }
+
+    public func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
+        // 사용자가 Apple 로그인 sheet를 닫은 경우입니다. 네트워크/서버 실패와 구분해서 전달합니다.
+        if let authorizationError = error as? ASAuthorizationError, authorizationError.code == .canceled {
+            resume(throwing: SocialAuthClientError.underlying("🍏 Apple 로그인 취소"))
+            return
+        }
+
+        resume(throwing: SocialAuthClientError.underlying(error.localizedDescription))
+    }
+}
+
+private extension AppleLoginService {
+    /// 성공 callback을 async 호출자에게 전달하고 continuation을 정리합니다.
+    func resume(returning token: SocialAuthToken) {
+        continuation?.resume(returning: token)
+        continuation = nil
+    }
+
+    /// 실패 callback을 async 호출자에게 전달하고 continuation을 정리합니다.
+    func resume(throwing error: Error) {
+        continuation?.resume(throwing: error)
+        continuation = nil
+    }
+}

--- a/Projects/Data/Service/Sources/Auth/KakaoLoginService.swift
+++ b/Projects/Data/Service/Sources/Auth/KakaoLoginService.swift
@@ -2,8 +2,6 @@
 //  KakaoLoginService.swift
 //  Service
 //
-//  Created by DDD-iOS2 on 5/4/26.
-//
 
 import DomainInterface
 import Entity

--- a/Projects/Data/Service/Sources/Auth/NaverLoginService.swift
+++ b/Projects/Data/Service/Sources/Auth/NaverLoginService.swift
@@ -2,8 +2,6 @@
 //  NaverLoginService.swift
 //  Service
 //
-//  Created by DDD-iOS2 on 5/6/26.
-//
 
 import DomainInterface
 import Entity

--- a/Projects/Data/Service/Sources/Base.swift
+++ b/Projects/Data/Service/Sources/Base.swift
@@ -2,7 +2,6 @@
 //  base.swift
 //  DDDAttendance.
 //
-//  Created by DDD-iOS2 on 4/7/26.
 //  Copyright © 2025 DDD , Ltd., All rights reserved.
 //
 

--- a/Projects/Domain/DataInterface/DataInterfaceTests/Sources/Test.swift
+++ b/Projects/Domain/DataInterface/DataInterfaceTests/Sources/Test.swift
@@ -2,7 +2,6 @@
 //  base.swift
 //  DDDAttendance
 //
-//  Created by DDD-iOS2 on 4/7/26.
 //  Copyright © 2025 DDD , Ltd. All rights reserved.
 //
 

--- a/Projects/Domain/DataInterface/Sources/AuthRepositoryProtocol.swift
+++ b/Projects/Domain/DataInterface/Sources/AuthRepositoryProtocol.swift
@@ -2,9 +2,6 @@
 //  AuthRepositoryProtocol.swift
 //  DataInterface
 //
-//  Created by DDD-iOS2 on 4/28/26.
-//  Copyright (c) 2025 DDD, Ltd., All rights reserved.
-//
 
 import Entity
 

--- a/Projects/Domain/DataInterface/Sources/Base.swift
+++ b/Projects/Domain/DataInterface/Sources/Base.swift
@@ -2,7 +2,6 @@
 //  base.swift
 //  DDDAttendance.
 //
-//  Created by DDD-iOS2 on 4/7/26.
 //  Copyright © 2025 DDD , Ltd., All rights reserved.
 //
 

--- a/Projects/Domain/DomainInterface/DomainInterfaceTests/Sources/Test.swift
+++ b/Projects/Domain/DomainInterface/DomainInterfaceTests/Sources/Test.swift
@@ -2,7 +2,6 @@
 //  base.swift
 //  DDDAttendance
 //
-//  Created by DDD-iOS2 on 4/7/26.
 //  Copyright © 2025 DDD , Ltd. All rights reserved.
 //
 

--- a/Projects/Domain/DomainInterface/Sources/SocialAuthClientError.swift
+++ b/Projects/Domain/DomainInterface/Sources/SocialAuthClientError.swift
@@ -2,8 +2,6 @@
 //  SocialAuthClientError.swift
 //  DomainInterface
 //
-//  Created by yeosong on 4/25/26.
-//
 
 import Entity
 import Foundation

--- a/Projects/Domain/Entity/EntityTests/Sources/Test.swift
+++ b/Projects/Domain/Entity/EntityTests/Sources/Test.swift
@@ -2,7 +2,6 @@
 //  base.swift
 //  DDDAttendance
 //
-//  Created by DDD-iOS2 on 4/7/26.
 //  Copyright © 2025 DDD , Ltd. All rights reserved.
 //
 

--- a/Projects/Domain/Entity/Sources/AuthTokens.swift
+++ b/Projects/Domain/Entity/Sources/AuthTokens.swift
@@ -2,8 +2,6 @@
 //  AuthTokens.swift
 //  Entity
 //
-//  Created by DDD-iOS2 on 5/6/26.
-//
 
 /// 인증에 사용하는 액세스/리프레시 토큰 쌍입니다.
 public struct AuthTokens: Equatable, Sendable {

--- a/Projects/Domain/Entity/Sources/LoginResult.swift
+++ b/Projects/Domain/Entity/Sources/LoginResult.swift
@@ -2,8 +2,6 @@
 //  LoginResult.swift
 //  Entity
 //
-//  Created by DDD-iOS2 on 5/6/26.
-//
 
 /// 서버 로그인 API 응답으로 받은 로그인 결과 도메인 모델입니다.
 public struct LoginResult: Equatable, Sendable {

--- a/Projects/Domain/Entity/Sources/SocialAuthProvider.swift
+++ b/Projects/Domain/Entity/Sources/SocialAuthProvider.swift
@@ -2,8 +2,6 @@
 //  SocialAuthProvider.swift
 //  Entity
 //
-//  Created by yeosong on 4/25/26.
-//
 
 /// `LoginFeature`는 이 enum 값만 보고 어떤 소셜 로그인을 요청할지 결정합니다.
 /// 각 제공자의 실제 SDK 타입이나 구현 방식은 `Presentation` 모듈 밖에서 처리합니다.

--- a/Projects/Domain/Entity/Sources/SocialAuthToken.swift
+++ b/Projects/Domain/Entity/Sources/SocialAuthToken.swift
@@ -2,8 +2,6 @@
 //  SocialAuthToken.swift
 //  Entity
 //
-//  Created by yeosong on 4/25/26.
-//
 
 /// 소셜 로그인 SDK에서 발급받은 인증 토큰을 앱 공통 형태로 표현한 모델입니다.
 ///

--- a/Projects/Domain/UseCase/Sources/Auth/SignInWithSocialUseCase.swift
+++ b/Projects/Domain/UseCase/Sources/Auth/SignInWithSocialUseCase.swift
@@ -2,8 +2,6 @@
 //  SignInWithSocialUseCase.swift
 //  UseCase
 //
-//  Created by DDD-iOS2 on 5/4/26.
-//
 
 import Entity
 

--- a/Projects/Domain/UseCase/Sources/Base.swift
+++ b/Projects/Domain/UseCase/Sources/Base.swift
@@ -2,7 +2,6 @@
 //  base.swift
 //  DDDAttendance.
 //
-//  Created by DDD-iOS2 on 4/7/26.
 //  Copyright © 2025 DDD , Ltd., All rights reserved.
 //
 

--- a/Projects/Domain/UseCase/Tests/Sources/Test.swift
+++ b/Projects/Domain/UseCase/Tests/Sources/Test.swift
@@ -2,7 +2,6 @@
 //  base.swift
 //  DDDAttendance
 //
-//  Created by DDD-iOS2 on 4/7/26.
 //  Copyright © 2025 DDD , Ltd. All rights reserved.
 //
 

--- a/Projects/Network/Foundations/FoundationsTests/Sources/Test.swift
+++ b/Projects/Network/Foundations/FoundationsTests/Sources/Test.swift
@@ -2,7 +2,6 @@
 //  base.swift
 //  DDDAttendance
 //
-//  Created by DDD-iOS2 on 4/7/26.
 //  Copyright © 2025 DDD , Ltd. All rights reserved.
 //
 

--- a/Projects/Network/Foundations/Sources/APITask.swift
+++ b/Projects/Network/Foundations/Sources/APITask.swift
@@ -2,7 +2,6 @@
 //  APITask.swift
 //  Foundations
 //
-//  Created by DDD-iOS2 on 4/13/26.
 //  Copyright © 2025 DDD, Ltd., All rights reserved.
 //
 

--- a/Projects/Network/Foundations/Sources/Base.swift
+++ b/Projects/Network/Foundations/Sources/Base.swift
@@ -2,7 +2,6 @@
 //  base.swift
 //  DDDAttendance.
 //
-//  Created by DDD-iOS2 on 4/7/26.
 //  Copyright © 2025 DDD , Ltd., All rights reserved.
 //
 

--- a/Projects/Network/Foundations/Sources/EndPoint.swift
+++ b/Projects/Network/Foundations/Sources/EndPoint.swift
@@ -2,7 +2,6 @@
 //  EndPoint.swift
 //  Foundations
 //
-//  Created by DDD-iOS2 on 4/13/26.
 //  Copyright © 2025 DDD, Ltd., All rights reserved.
 //
 

--- a/Projects/Network/Networking/NetworkingTests/Sources/Test.swift
+++ b/Projects/Network/Networking/NetworkingTests/Sources/Test.swift
@@ -2,7 +2,6 @@
 //  base.swift
 //  DDDAttendance
 //
-//  Created by DDD-iOS2 on 4/7/26.
 //  Copyright © 2025 DDD , Ltd. All rights reserved.
 //
 

--- a/Projects/Network/Networking/Sources/Error/NetworkError.swift
+++ b/Projects/Network/Networking/Sources/Error/NetworkError.swift
@@ -2,8 +2,6 @@
 //  AuthError.swift
 //  Networking
 //
-//  Created by yeosong on 4/16/26.
-//
 
 import Foundation
 

--- a/Projects/Network/Networking/Sources/Exorted/NetworkExported.swift
+++ b/Projects/Network/Networking/Sources/Exorted/NetworkExported.swift
@@ -2,5 +2,3 @@
 //  NetworkExported.swift
 //  Network
 //
-//  Created by DDD-iOS2 on 4/7/26.
-//

--- a/Projects/Network/Networking/Sources/Interceptor.swift
+++ b/Projects/Network/Networking/Sources/Interceptor.swift
@@ -2,8 +2,6 @@
 //  Interceptor.swift
 //  Networking
 //
-//  Created by yeosong on 4/13/26.
-//
 
 import Foundation
 import Alamofire

--- a/Projects/Network/Networking/Sources/NetworkManager.swift
+++ b/Projects/Network/Networking/Sources/NetworkManager.swift
@@ -2,8 +2,6 @@
 //  NetworkManager.swift
 //  Networking
 //
-//  Created by yeosong on 4/14/26.
-//
 
 import Foundation
 import Alamofire

--- a/Projects/Shared/DesignSystem/DesignSystemTests/Sources/Test.swift
+++ b/Projects/Shared/DesignSystem/DesignSystemTests/Sources/Test.swift
@@ -2,7 +2,6 @@
 //  base.swift
 //  DDDAttendance
 //
-//  Created by DDD-iOS2 on 4/7/26.
 //  Copyright © 2025 DDD , Ltd. All rights reserved.
 //
 

--- a/Projects/Shared/DesignSystem/Sources/Color/ShapeStyle+.swift
+++ b/Projects/Shared/DesignSystem/Sources/Color/ShapeStyle+.swift
@@ -2,8 +2,6 @@
 //  ShapeStyle.swift
 //  DesignSystem
 //
-//  Created by DDD-iOS2 on 4/7/26.
-//
 
 import SwiftUI
 

--- a/Projects/Shared/DesignSystem/Sources/CustomFont/CustomSize.swift
+++ b/Projects/Shared/DesignSystem/Sources/CustomFont/CustomSize.swift
@@ -2,8 +2,6 @@
 //  CustomSize.swift
 //  DesignSystem
 //
-//  Created by DDD-iOS2 on 4/7/26.
-//
 
 import Foundation
 

--- a/Projects/Shared/DesignSystem/Sources/CustomFont/PretendardFont.swift
+++ b/Projects/Shared/DesignSystem/Sources/CustomFont/PretendardFont.swift
@@ -2,8 +2,6 @@
 //  PretendardFont.swift
 //  DDDAttendance
 //
-//  Created by DDD-iOS2 on 4/7/26.
-//
 
 import SwiftUI
 

--- a/Projects/Shared/DesignSystem/Sources/CustomFont/PretendardFontFamily.swift
+++ b/Projects/Shared/DesignSystem/Sources/CustomFont/PretendardFontFamily.swift
@@ -2,8 +2,6 @@
 //  PretendardFontFamily.swift
 //  DesignSystem
 //
-//  Created by DDD-iOS2 on 4/7/26.
-//
 
 import Foundation
 

--- a/Projects/Shared/DesignSystem/Sources/Extension/Color/Color+.swift
+++ b/Projects/Shared/DesignSystem/Sources/Extension/Color/Color+.swift
@@ -2,8 +2,6 @@
 //  Color+.swift
 //  DDDAttendance
 //
-//  Created by DDD-iOS2 on 4/7/26.
-//
 
 import SwiftUI
 

--- a/Projects/Shared/DesignSystem/Sources/Extension/Color/UIColor+.swift
+++ b/Projects/Shared/DesignSystem/Sources/Extension/Color/UIColor+.swift
@@ -2,8 +2,6 @@
 //  UIColor+.swift
 //  DDDAttendance
 //
-//  Created by DDD-iOS2 on 4/7/26.
-//
 
 import UIKit
 

--- a/Projects/Shared/DesignSystem/Sources/Extension/Image/Image+.swift
+++ b/Projects/Shared/DesignSystem/Sources/Extension/Image/Image+.swift
@@ -2,8 +2,6 @@
 //  Image+.swift
 //  DesignSystem
 //
-//  Created by DDD-iOS2 on 4/7/26.
-//
 
 import UIKit
 

--- a/Projects/Shared/DesignSystem/Sources/Extension/Image/UIImage+.swift
+++ b/Projects/Shared/DesignSystem/Sources/Extension/Image/UIImage+.swift
@@ -2,8 +2,6 @@
 //  UIImage+.swift
 //  DesignSystem
 //
-//  Created by DDD-iOS2 on 4/7/26.
-//
 
 import SwiftUI
 

--- a/Projects/Shared/DesignSystem/Sources/Extension/ScreenSize/UIScreen+.swift
+++ b/Projects/Shared/DesignSystem/Sources/Extension/ScreenSize/UIScreen+.swift
@@ -2,8 +2,6 @@
 //  UIScreen+.swift
 //  DDDAttendance
 //
-//  Created by DDD-iOS2 on 4/7/26.
-//
 
 import SwiftUI
 

--- a/Projects/Shared/DesignSystem/Sources/Extension/UI/Navigaion/UINavigationController+gesture.swift
+++ b/Projects/Shared/DesignSystem/Sources/Extension/UI/Navigaion/UINavigationController+gesture.swift
@@ -2,8 +2,6 @@
 //  UINavigationController+gesture.swift
 //  DesignSystem
 //
-//  Created by DDD-iOS2 on 4/7/26.
-//
 
 import UIKit
 

--- a/Projects/Shared/DesignSystem/Sources/Image/ImageAsset.swift
+++ b/Projects/Shared/DesignSystem/Sources/Image/ImageAsset.swift
@@ -2,8 +2,6 @@
 //  ImageAsset.swift
 //  DesignSystem
 //
-//  Created by DDD-iOS2 on 4/7/26.
-//
 
 import Foundation
 

--- a/Projects/Shared/Shared/SharedTests/Sources/Test.swift
+++ b/Projects/Shared/Shared/SharedTests/Sources/Test.swift
@@ -2,7 +2,6 @@
 //  base.swift
 //  DDDAttendance
 //
-//  Created by DDD-iOS2 on 4/7/26.
 //  Copyright © 2025 DDD , Ltd. All rights reserved.
 //
 

--- a/Projects/Shared/Shared/Sources/Base.swift
+++ b/Projects/Shared/Shared/Sources/Base.swift
@@ -2,7 +2,6 @@
 //  base.swift
 //  DDDAttendance.
 //
-//  Created by DDD-iOS2 on 4/7/26.
 //  Copyright © 2025 DDD , Ltd., All rights reserved.
 //
 

--- a/Projects/Shared/Utill/Sources/KeyChainManager.swift
+++ b/Projects/Shared/Utill/Sources/KeyChainManager.swift
@@ -2,8 +2,6 @@
 //  KeyChainManager.swift
 //  Utill
 //
-//  Created by yeosong on 4/13/26.
-//
 
 import Foundation
 

--- a/Projects/Shared/Utill/Sources/Log.swift
+++ b/Projects/Shared/Utill/Sources/Log.swift
@@ -2,9 +2,6 @@
 //  Log.swift
 //  Utill
 //
-//  Created by DDD-iOS2 on 4/20/26.
-//  Copyright (c) 2025 DDD, Ltd., All rights reserved.
-//
 
 import os
 import Foundation

--- a/Projects/Shared/Utill/Sources/StorageKey.swift
+++ b/Projects/Shared/Utill/Sources/StorageKey.swift
@@ -2,9 +2,6 @@
 //  StorageKey.swift
 //  Utill
 //
-//  Created by DDD-iOS2 on 4/16/26.
-//  Copyright (c) 2025 DDD, Ltd., All rights reserved.
-//
 
 import Foundation
 

--- a/Projects/Shared/Utill/UtillTests/Sources/Test.swift
+++ b/Projects/Shared/Utill/UtillTests/Sources/Test.swift
@@ -2,7 +2,6 @@
 //  base.swift
 //  DDDAttendance
 //
-//  Created by DDD-iOS2 on 4/7/26.
 //  Copyright © 2025 DDD , Ltd. All rights reserved.
 //
 

--- a/Tuist/Templates/DemoModule/DemoModule.swift
+++ b/Tuist/Templates/DemoModule/DemoModule.swift
@@ -2,8 +2,6 @@
 //  DemoModule.swift
 //  Templates
 //
-//  Created by DDD-iOS2 on 4/7/26.
-//
 
 import Foundation
 import ProjectDescription

--- a/Tuist/Templates/Module/Module.swift
+++ b/Tuist/Templates/Module/Module.swift
@@ -2,8 +2,6 @@
 //  Module.swift
 //  Manifests
 //
-//  Created by DDD-iOS2 on 4/7/26.
-//
 
 import ProjectDescription
 import Foundation

--- a/Tuist/Templates/multi-module-project/multi-module-project.swift
+++ b/Tuist/Templates/multi-module-project/multi-module-project.swift
@@ -25,8 +25,6 @@ let template = Template(
 //  Project+Enviorment.swift
 //  MyPlugin
 //
-//  Created by DDD-iOS2 on 4/7/26.
-//
 
 import Foundation
 import ProjectDescription

--- a/TuistTool.swift
+++ b/TuistTool.swift
@@ -215,8 +215,6 @@ func generateProjectWithSettings(name: String, bundleIdPrefix: String, teamId: S
         //  \(name)Tests.swift
         //  \(name)Tests
         //
-        //  Created by TuistTool.
-        //
 
         import XCTest
 
@@ -1012,8 +1010,6 @@ let project = Project.makeAppModule(
           //
           //  Base.swift
           //  Domain.\(moduleName).Interface
-          //
-          //  Created by \(author) on \(currentDate).
           //
           
           import Foundation

--- a/WorkSpace.swift
+++ b/WorkSpace.swift
@@ -2,8 +2,6 @@
 //  WorkSpace.swift
 //  Manifests
 //
-//  Created by DDD-iOS2 on 4/7/26.
-//
 
 import Foundation
 import ProjectDescription


### PR DESCRIPTION
## 작업 내용

- Apple 로그인 서비스를 추가
  - `ASAuthorizationController` delegate 기반 API를 `async/await` 형태로 래핑
  - Apple `identityToken`을 `SocialAuthToken`으로 변환
  - 로그인 중복 요청 방어
  - 로그인 취소/토큰 누락 에러 처리
  - 현재 key window를 기준으로 Apple 로그인 sheet 표시

- 소셜 로그인 유스케이스에 Apple 로그인 플로우를 연결
  - `.apple` provider 선택 시 `AppleLoginService.login()` 실행
  - 발급받은 Apple identity token으로 서버 소셜 로그인 요청

- 인증 의존성 조립을 갱신
  - `AuthFactory`에서 `AppleLoginService`를 함께 주입
  - 기존 Kakao/Naver 로그인 서비스와 동일한 구조로 Apple 로그인 추가

- 기타
  - `DataUseCase` 테스트 타겟 기본 테스트 파일 추가
  - 불필요한 파일 헤더 주석 정리


## 참고 사항

- 현재 서버 연동에는 Apple `identityToken`을 전달하도록 구현했습니다.