### PR TITLE
[CHORE] design-tokens 자동 반영

### DIFF
--- a/Projects/Shared/DesignSystem/Sources/Color/Generated/Colors+Generated.swift
+++ b/Projects/Shared/DesignSystem/Sources/Color/Generated/Colors+Generated.swift
@@ -6,7 +6,8 @@
 
 import SwiftUI
 
-private let designSystemBundle = Bundle.module
+private final class DesignSystemBundleToken {}
+private let designSystemBundle = Bundle(for: DesignSystemBundleToken.self)
 
 public enum Colors {
     // MARK: - Orange

--- a/Projects/Shared/DesignSystem/Sources/CustomFont/Generated/Typography+Generated.swift
+++ b/Projects/Shared/DesignSystem/Sources/CustomFont/Generated/Typography+Generated.swift
@@ -17,7 +17,6 @@ public enum Typography {
     public static let typographyWeight700: UIFont.Weight = .bold
 
     // MARK: - Font Size
-    public static let typographySize50: CGFloat = 11
     public static let typographySize100: CGFloat = 11
     public static let typographySize200: CGFloat = 13
     public static let typographySize300: CGFloat = 15
@@ -27,10 +26,8 @@ public enum Typography {
     public static let typographySize700: CGFloat = 25
     public static let typographySize800: CGFloat = 29
     public static let typographySize900: CGFloat = 31
-    public static let typographySize1000: CGFloat = 86
 
     // MARK: - Line Height
-    public static let typographyLineHeight50: CGFloat = 15
     public static let typographyLineHeight100: CGFloat = 15
     public static let typographyLineHeight200: CGFloat = 18
     public static let typographyLineHeight300: CGFloat = 22
@@ -40,7 +37,6 @@ public enum Typography {
     public static let typographyLineHeight700: CGFloat = 34
     public static let typographyLineHeight800: CGFloat = 40
     public static let typographyLineHeight900: CGFloat = 44
-    public static let typographyLineHeight1000: CGFloat = 114
 
     // MARK: - Letter Spacing (em fraction)
     public static let typographyLetterSpacing000: CGFloat = 0

--- a/Projects/Shared/DesignSystem/Sources/Tokens/Generated/BorderRadius+Generated.swift
+++ b/Projects/Shared/DesignSystem/Sources/Tokens/Generated/BorderRadius+Generated.swift
@@ -13,6 +13,7 @@ public enum BorderRadius {
     public static let borderRadius225: CGFloat = 10
     public static let borderRadius250: CGFloat = 12
     public static let borderRadius300: CGFloat = 16
+    public static let borderRadius350: CGFloat = 20
     public static let borderRadius400: CGFloat = 24
     public static let borderRadius50: CGFloat = 2
     public static let borderRadius500: CGFloat = 32

--- a/Projects/Shared/DesignSystem/Sources/Tokens/Generated/BoxShadow+Generated.swift
+++ b/Projects/Shared/DesignSystem/Sources/Tokens/Generated/BoxShadow+Generated.swift
@@ -27,20 +27,20 @@ public enum BoxShadow {
         offsetY: 4,
         blur: 10,
         spread: 0,
-        color: Color(red: 0, green: 0, blue: 0, opacity: 0.161)
+        color: Color(red: 0, green: 0, blue: 0, opacity: 0.122)
     )
     public static let boxShadow300 = DesignTokenShadow(
         offsetX: 0,
-        offsetY: 2,
+        offsetY: 4,
         blur: 20,
         spread: 0,
-        color: Color(red: 0, green: 0, blue: 0, opacity: 0.2)
+        color: Color(red: 0.169, green: 0.169, blue: 0.169, opacity: 0.122)
     )
     public static let boxShadow400 = DesignTokenShadow(
         offsetX: 0,
-        offsetY: 16,
-        blur: 40,
+        offsetY: 4,
+        blur: 24,
         spread: 0,
-        color: Color(red: 0, green: 0, blue: 0, opacity: 0.2)
+        color: Color(red: 0.169, green: 0.169, blue: 0.169, opacity: 0.122)
     )
 }

--- a/Projects/Shared/DesignSystem/Sources/Tokens/Generated/Sizing+Generated.swift
+++ b/Projects/Shared/DesignSystem/Sources/Tokens/Generated/Sizing+Generated.swift
@@ -8,6 +8,7 @@ import CoreGraphics
 
 public enum Sizing {
     public static let sizing100: CGFloat = 16
+    public static let sizing1000: CGFloat = 280
     public static let sizing150: CGFloat = 20
     public static let sizing200: CGFloat = 24
     public static let sizing300: CGFloat = 32
@@ -16,10 +17,13 @@ public enum Sizing {
     public static let sizing400: CGFloat = 40
     public static let sizing425: CGFloat = 42
     public static let sizing450: CGFloat = 44
+    public static let sizing50: CGFloat = 8
     public static let sizing500: CGFloat = 48
     public static let sizing550: CGFloat = 52
     public static let sizing600: CGFloat = 56
     public static let sizing700: CGFloat = 64
+    public static let sizing75: CGFloat = 12
+    public static let sizing750: CGFloat = 82
     public static let sizing800: CGFloat = 104
     public static let sizing900: CGFloat = 112
 }


### PR DESCRIPTION
## 자동 생성된 디자인 토큰 반영

**Source**: [`zizizoi0709-p/design-tokens@62cdfc28d1d4b62b6e22207cbe61712c8cd974d1`](https://github.com/zizizoi0709-p/design-tokens/commit/62cdfc28d1d4b62b6e22207cbe61712c8cd974d1)
**Trigger**: `push` on `main`
**Workflow run**: [#3](https://github.com/zizizoi0709-p/design-tokens/actions/runs/26211597379)
**Branch**: `chore/design-tokens-sync-20260521-072031` → `develop`

### 변경된 파일 (베이스: `Projects/Shared/DesignSystem/`)
- `Resources/Colors.xcassets/` (Asset Catalog)
- `Sources/Color/Generated/Colors+Generated.swift`
- `Sources/CustomFont/Generated/Typography+Generated.swift`
- `Sources/Tokens/Generated/Spacing+Generated.swift`
- `Sources/Tokens/Generated/Sizing+Generated.swift`
- `Sources/Tokens/Generated/BorderRadius+Generated.swift`
- `Sources/Tokens/Generated/BorderWidth+Generated.swift`
- `Sources/Tokens/Generated/Opacity+Generated.swift`
- `Sources/Tokens/Generated/BoxShadow+Generated.swift`

### 머지 후 작업
신규 파일이 Xcode 프로젝트에 반영되도록 로컬에서 아래를 실행한다.

```bash
./tuisttool generate && tuist graph
```

> 자동 생성된 PR입니다. 토큰 변경 시마다 새 브랜치/새 PR이 생성되므로
> 머지하지 않은 채로 누적될 수 있습니다. 머지 후엔 브랜치가 자동 삭제됩니다.