### PR TITLE
[CHORE] design-tokens 자동 반영

### DIFF
--- a/Projects/Shared/DesignSystem/Resources/Colors.xcassets/Gray00.colorset/Contents.json
+++ b/Projects/Shared/DesignSystem/Resources/Colors.xcassets/Gray00.colorset/Contents.json
@@ -33,9 +33,9 @@
       "color": {
         "color-space": "srgb",
         "components": {
-          "red": "0x18",
-          "green": "0x18",
-          "blue": "0x1B",
+          "red": "0x17",
+          "green": "0x17",
+          "blue": "0x1C",
           "alpha": "1.000"
         }
       }

--- a/Projects/Shared/DesignSystem/Resources/Colors.xcassets/Gray100.colorset/Contents.json
+++ b/Projects/Shared/DesignSystem/Resources/Colors.xcassets/Gray100.colorset/Contents.json
@@ -15,9 +15,9 @@
       "color": {
         "color-space": "srgb",
         "components": {
-          "red": "0xF7",
-          "green": "0xF7",
-          "blue": "0xF7",
+          "red": "0xF6",
+          "green": "0xF5",
+          "blue": "0xF8",
           "alpha": "1.000"
         }
       }
@@ -33,9 +33,9 @@
       "color": {
         "color-space": "srgb",
         "components": {
-          "red": "0x23",
-          "green": "0x23",
-          "blue": "0x29",
+          "red": "0x1F",
+          "green": "0x1F",
+          "blue": "0x24",
           "alpha": "1.000"
         }
       }

--- a/Projects/Shared/DesignSystem/Resources/Colors.xcassets/Gray200.colorset/Contents.json
+++ b/Projects/Shared/DesignSystem/Resources/Colors.xcassets/Gray200.colorset/Contents.json
@@ -15,9 +15,9 @@
       "color": {
         "color-space": "srgb",
         "components": {
-          "red": "0xE4",
-          "green": "0xE4",
-          "blue": "0xE7",
+          "red": "0xF3",
+          "green": "0xF2",
+          "blue": "0xF3",
           "alpha": "1.000"
         }
       }
@@ -33,9 +33,9 @@
       "color": {
         "color-space": "srgb",
         "components": {
-          "red": "0x2D",
-          "green": "0x2D",
-          "blue": "0x36",
+          "red": "0x25",
+          "green": "0x25",
+          "blue": "0x2D",
           "alpha": "1.000"
         }
       }

--- a/Projects/Shared/DesignSystem/Resources/Colors.xcassets/Gray300.colorset/Contents.json
+++ b/Projects/Shared/DesignSystem/Resources/Colors.xcassets/Gray300.colorset/Contents.json
@@ -15,9 +15,9 @@
       "color": {
         "color-space": "srgb",
         "components": {
-          "red": "0xDC",
-          "green": "0xDD",
-          "blue": "0xE0",
+          "red": "0xE8",
+          "green": "0xE6",
+          "blue": "0xEA",
           "alpha": "1.000"
         }
       }
@@ -33,9 +33,9 @@
       "color": {
         "color-space": "srgb",
         "components": {
-          "red": "0x3C",
-          "green": "0x3C",
-          "blue": "0x46",
+          "red": "0x3D",
+          "green": "0x3D",
+          "blue": "0x45",
           "alpha": "1.000"
         }
       }

--- a/Projects/Shared/DesignSystem/Resources/Colors.xcassets/Gray400.colorset/Contents.json
+++ b/Projects/Shared/DesignSystem/Resources/Colors.xcassets/Gray400.colorset/Contents.json
@@ -15,9 +15,9 @@
       "color": {
         "color-space": "srgb",
         "components": {
-          "red": "0xC8",
-          "green": "0xC9",
-          "blue": "0xD0",
+          "red": "0xD2",
+          "green": "0xD1",
+          "blue": "0xD6",
           "alpha": "1.000"
         }
       }
@@ -33,9 +33,9 @@
       "color": {
         "color-space": "srgb",
         "components": {
-          "red": "0x56",
-          "green": "0x57",
-          "blue": "0x68",
+          "red": "0x5A",
+          "green": "0x5B",
+          "blue": "0x64",
           "alpha": "1.000"
         }
       }

--- a/Projects/Shared/DesignSystem/Resources/Colors.xcassets/Gray50.colorset/Contents.json
+++ b/Projects/Shared/DesignSystem/Resources/Colors.xcassets/Gray50.colorset/Contents.json
@@ -16,8 +16,8 @@
         "color-space": "srgb",
         "components": {
           "red": "0xFA",
-          "green": "0xFA",
-          "blue": "0xFA",
+          "green": "0xF9",
+          "blue": "0xFB",
           "alpha": "1.000"
         }
       }
@@ -33,9 +33,9 @@
       "color": {
         "color-space": "srgb",
         "components": {
-          "red": "0x1C",
-          "green": "0x1C",
-          "blue": "0x22",
+          "red": "0x19",
+          "green": "0x19",
+          "blue": "0x1F",
           "alpha": "1.000"
         }
       }

--- a/Projects/Shared/DesignSystem/Resources/Colors.xcassets/Gray500.colorset/Contents.json
+++ b/Projects/Shared/DesignSystem/Resources/Colors.xcassets/Gray500.colorset/Contents.json
@@ -15,9 +15,9 @@
       "color": {
         "color-space": "srgb",
         "components": {
-          "red": "0xA4",
-          "green": "0xA5",
-          "blue": "0xB2",
+          "red": "0xBA",
+          "green": "0xB8",
+          "blue": "0xC2",
           "alpha": "1.000"
         }
       }
@@ -33,9 +33,9 @@
       "color": {
         "color-space": "srgb",
         "components": {
-          "red": "0x82",
-          "green": "0x84",
-          "blue": "0x99",
+          "red": "0x74",
+          "green": "0x75",
+          "blue": "0x81",
           "alpha": "1.000"
         }
       }

--- a/Projects/Shared/DesignSystem/Resources/Colors.xcassets/Gray600.colorset/Contents.json
+++ b/Projects/Shared/DesignSystem/Resources/Colors.xcassets/Gray600.colorset/Contents.json
@@ -15,9 +15,9 @@
       "color": {
         "color-space": "srgb",
         "components": {
-          "red": "0x80",
-          "green": "0x82",
-          "blue": "0x93",
+          "red": "0x8E",
+          "green": "0x8D",
+          "blue": "0x96",
           "alpha": "1.000"
         }
       }
@@ -33,9 +33,9 @@
       "color": {
         "color-space": "srgb",
         "components": {
-          "red": "0xA8",
-          "green": "0xA9",
-          "blue": "0xBB",
+          "red": "0xB7",
+          "green": "0xB8",
+          "blue": "0xBD",
           "alpha": "1.000"
         }
       }

--- a/Projects/Shared/DesignSystem/Resources/Colors.xcassets/Gray700.colorset/Contents.json
+++ b/Projects/Shared/DesignSystem/Resources/Colors.xcassets/Gray700.colorset/Contents.json
@@ -15,9 +15,9 @@
       "color": {
         "color-space": "srgb",
         "components": {
-          "red": "0x59",
-          "green": "0x5A",
-          "blue": "0x69",
+          "red": "0x66",
+          "green": "0x65",
+          "blue": "0x6C",
           "alpha": "1.000"
         }
       }
@@ -33,9 +33,9 @@
       "color": {
         "color-space": "srgb",
         "components": {
-          "red": "0xD3",
-          "green": "0xD3",
-          "blue": "0xDE",
+          "red": "0xDA",
+          "green": "0xDA",
+          "blue": "0xDD",
           "alpha": "1.000"
         }
       }

--- a/Projects/Shared/DesignSystem/Resources/Colors.xcassets/Gray800.colorset/Contents.json
+++ b/Projects/Shared/DesignSystem/Resources/Colors.xcassets/Gray800.colorset/Contents.json
@@ -15,9 +15,9 @@
       "color": {
         "color-space": "srgb",
         "components": {
-          "red": "0x3A",
-          "green": "0x3A",
-          "blue": "0x41",
+          "red": "0x39",
+          "green": "0x38",
+          "blue": "0x3E",
           "alpha": "1.000"
         }
       }
@@ -33,8 +33,8 @@
       "color": {
         "color-space": "srgb",
         "components": {
-          "red": "0xE8",
-          "green": "0xE8",
+          "red": "0xEC",
+          "green": "0xEC",
           "blue": "0xEE",
           "alpha": "1.000"
         }

--- a/Projects/Shared/DesignSystem/Resources/Colors.xcassets/GrayAlpha100.colorset/Contents.json
+++ b/Projects/Shared/DesignSystem/Resources/Colors.xcassets/GrayAlpha100.colorset/Contents.json
@@ -15,10 +15,10 @@
       "color": {
         "color-space": "srgb",
         "components": {
-          "red": "0x00",
-          "green": "0x00",
-          "blue": "0x00",
-          "alpha": "0.031"
+          "red": "0x2B",
+          "green": "0x2B",
+          "blue": "0x3B",
+          "alpha": "0.039"
         }
       }
     },
@@ -33,10 +33,10 @@
       "color": {
         "color-space": "srgb",
         "components": {
-          "red": "0x9C",
-          "green": "0x9C",
-          "blue": "0xC3",
-          "alpha": "0.059"
+          "red": "0x93",
+          "green": "0x93",
+          "blue": "0xA6",
+          "alpha": "0.078"
         }
       }
     }

--- a/Projects/Shared/DesignSystem/Resources/Colors.xcassets/GrayAlpha200.colorset/Contents.json
+++ b/Projects/Shared/DesignSystem/Resources/Colors.xcassets/GrayAlpha200.colorset/Contents.json
@@ -15,10 +15,10 @@
       "color": {
         "color-space": "srgb",
         "components": {
-          "red": "0x1D",
-          "green": "0x1D",
-          "blue": "0x3A",
-          "alpha": "0.071"
+          "red": "0x29",
+          "green": "0x29",
+          "blue": "0x3D",
+          "alpha": "0.059"
         }
       }
     },
@@ -33,10 +33,10 @@
       "color": {
         "color-space": "srgb",
         "components": {
-          "red": "0x90",
-          "green": "0x90",
-          "blue": "0xBC",
-          "alpha": "0.110"
+          "red": "0xA4",
+          "green": "0xA4",
+          "blue": "0xB7",
+          "alpha": "0.141"
         }
       }
     }

--- a/Projects/Shared/DesignSystem/Resources/Colors.xcassets/GrayAlpha300.colorset/Contents.json
+++ b/Projects/Shared/DesignSystem/Resources/Colors.xcassets/GrayAlpha300.colorset/Contents.json
@@ -15,10 +15,10 @@
       "color": {
         "color-space": "srgb",
         "components": {
-          "red": "0x0B",
-          "green": "0x0B",
+          "red": "0x14",
+          "green": "0x14",
           "blue": "0x24",
-          "alpha": "0.161"
+          "alpha": "0.122"
         }
       }
     },
@@ -33,10 +33,10 @@
       "color": {
         "color-space": "srgb",
         "components": {
-          "red": "0xA6",
-          "green": "0xA6",
-          "blue": "0xC9",
-          "alpha": "0.161"
+          "red": "0xB7",
+          "green": "0xB7",
+          "blue": "0xCB",
+          "alpha": "0.231"
         }
       }
     }

--- a/Projects/Shared/DesignSystem/Resources/Colors.xcassets/GrayAlpha400.colorset/Contents.json
+++ b/Projects/Shared/DesignSystem/Resources/Colors.xcassets/GrayAlpha400.colorset/Contents.json
@@ -15,9 +15,9 @@
       "color": {
         "color-space": "srgb",
         "components": {
-          "red": "0x07",
-          "green": "0x0B",
-          "blue": "0x28",
+          "red": "0x11",
+          "green": "0x13",
+          "blue": "0x1E",
           "alpha": "0.271"
         }
       }
@@ -33,10 +33,10 @@
       "color": {
         "color-space": "srgb",
         "components": {
-          "red": "0xA6",
-          "green": "0xA6",
-          "blue": "0xC9",
-          "alpha": "0.259"
+          "red": "0xCC",
+          "green": "0xCC",
+          "blue": "0xDC",
+          "alpha": "0.278"
         }
       }
     }

--- a/Projects/Shared/DesignSystem/Resources/Colors.xcassets/GrayAlpha50.colorset/Contents.json
+++ b/Projects/Shared/DesignSystem/Resources/Colors.xcassets/GrayAlpha50.colorset/Contents.json
@@ -33,10 +33,10 @@
       "color": {
         "color-space": "srgb",
         "components": {
-          "red": "0x9C",
-          "green": "0x9C",
-          "blue": "0xC3",
-          "alpha": "0.059"
+          "red": "0x91",
+          "green": "0x91",
+          "blue": "0xA1",
+          "alpha": "0.031"
         }
       }
     }

--- a/Projects/Shared/DesignSystem/Resources/Colors.xcassets/GrayAlpha500.colorset/Contents.json
+++ b/Projects/Shared/DesignSystem/Resources/Colors.xcassets/GrayAlpha500.colorset/Contents.json
@@ -15,9 +15,9 @@
       "color": {
         "color-space": "srgb",
         "components": {
-          "red": "0x02",
-          "green": "0x06",
-          "blue": "0x27",
+          "red": "0x0F",
+          "green": "0x10",
+          "blue": "0x1A",
           "alpha": "0.431"
         }
       }
@@ -33,10 +33,10 @@
       "color": {
         "color-space": "srgb",
         "components": {
-          "red": "0xAB",
-          "green": "0xAB",
-          "blue": "0xC9",
-          "alpha": "0.400"
+          "red": "0xE1",
+          "green": "0xE1",
+          "blue": "0xE9",
+          "alpha": "0.478"
         }
       }
     }

--- a/Projects/Shared/DesignSystem/Resources/Colors.xcassets/GrayAlpha600.colorset/Contents.json
+++ b/Projects/Shared/DesignSystem/Resources/Colors.xcassets/GrayAlpha600.colorset/Contents.json
@@ -15,9 +15,9 @@
       "color": {
         "color-space": "srgb",
         "components": {
-          "red": "0x00",
-          "green": "0x01",
-          "blue": "0x24",
+          "red": "0x0D",
+          "green": "0x0E",
+          "blue": "0x17",
           "alpha": "0.541"
         }
       }
@@ -33,10 +33,10 @@
       "color": {
         "color-space": "srgb",
         "components": {
-          "red": "0xB9",
-          "green": "0xB9",
-          "blue": "0xD5",
-          "alpha": "0.522"
+          "red": "0xEB",
+          "green": "0xEB",
+          "blue": "0xF0",
+          "alpha": "0.549"
         }
       }
     }

--- a/Projects/Shared/DesignSystem/Resources/Colors.xcassets/GrayAlpha700.colorset/Contents.json
+++ b/Projects/Shared/DesignSystem/Resources/Colors.xcassets/GrayAlpha700.colorset/Contents.json
@@ -15,10 +15,10 @@
       "color": {
         "color-space": "srgb",
         "components": {
-          "red": "0x02",
-          "green": "0x02",
-          "blue": "0x17",
-          "alpha": "0.678"
+          "red": "0x09",
+          "green": "0x09",
+          "blue": "0x10",
+          "alpha": "0.761"
         }
       }
     },
@@ -33,9 +33,9 @@
       "color": {
         "color-space": "srgb",
         "components": {
-          "red": "0xC4",
-          "green": "0xC4",
-          "blue": "0xD4",
+          "red": "0xEF",
+          "green": "0xEF",
+          "blue": "0xF0",
           "alpha": "0.690"
         }
       }

--- a/Projects/Shared/DesignSystem/Resources/Colors.xcassets/GrayAlpha800.colorset/Contents.json
+++ b/Projects/Shared/DesignSystem/Resources/Colors.xcassets/GrayAlpha800.colorset/Contents.json
@@ -15,10 +15,10 @@
       "color": {
         "color-space": "srgb",
         "components": {
-          "red": "0x00",
-          "green": "0x00",
-          "blue": "0x0A",
-          "alpha": "0.780"
+          "red": "0x04",
+          "green": "0x04",
+          "blue": "0x06",
+          "alpha": "0.839"
         }
       }
     },
@@ -33,10 +33,10 @@
       "color": {
         "color-space": "srgb",
         "components": {
-          "red": "0xCC",
-          "green": "0xCC",
-          "blue": "0xD6",
-          "alpha": "0.839"
+          "red": "0xEF",
+          "green": "0xEF",
+          "blue": "0xF0",
+          "alpha": "0.820"
         }
       }
     }

--- a/Projects/Shared/DesignSystem/Resources/Colors.xcassets/GrayAlpha900.colorset/Contents.json
+++ b/Projects/Shared/DesignSystem/Resources/Colors.xcassets/GrayAlpha900.colorset/Contents.json
@@ -15,10 +15,10 @@
       "color": {
         "color-space": "srgb",
         "components": {
-          "red": "0x00",
-          "green": "0x00",
+          "red": "0x04",
+          "green": "0x04",
           "blue": "0x06",
-          "alpha": "0.910"
+          "alpha": "0.839"
         }
       }
     },
@@ -33,10 +33,10 @@
       "color": {
         "color-space": "srgb",
         "components": {
-          "red": "0xE2",
-          "green": "0xE2",
-          "blue": "0xE8",
-          "alpha": "0.922"
+          "red": "0xF7",
+          "green": "0xF7",
+          "blue": "0xF8",
+          "alpha": "0.902"
         }
       }
     }

--- a/Projects/Shared/DesignSystem/Sources/Color/Generated/Colors+Generated.swift
+++ b/Projects/Shared/DesignSystem/Sources/Color/Generated/Colors+Generated.swift
@@ -6,7 +6,8 @@
 
 import SwiftUI
 
-private let designSystemBundle = Bundle.module
+private final class DesignSystemBundleToken {}
+private let designSystemBundle = Bundle(for: DesignSystemBundleToken.self)
 
 public enum Colors {
     // MARK: - Orange

--- a/Projects/Shared/DesignSystem/Sources/CustomFont/Generated/Typography+Generated.swift
+++ b/Projects/Shared/DesignSystem/Sources/CustomFont/Generated/Typography+Generated.swift
@@ -17,7 +17,6 @@ public enum Typography {
     public static let typographyWeight700: UIFont.Weight = .bold
 
     // MARK: - Font Size
-    public static let typographySize50: CGFloat = 11
     public static let typographySize100: CGFloat = 11
     public static let typographySize200: CGFloat = 13
     public static let typographySize300: CGFloat = 15
@@ -27,10 +26,8 @@ public enum Typography {
     public static let typographySize700: CGFloat = 25
     public static let typographySize800: CGFloat = 29
     public static let typographySize900: CGFloat = 31
-    public static let typographySize1000: CGFloat = 86
 
     // MARK: - Line Height
-    public static let typographyLineHeight50: CGFloat = 15
     public static let typographyLineHeight100: CGFloat = 15
     public static let typographyLineHeight200: CGFloat = 18
     public static let typographyLineHeight300: CGFloat = 22
@@ -40,7 +37,6 @@ public enum Typography {
     public static let typographyLineHeight700: CGFloat = 34
     public static let typographyLineHeight800: CGFloat = 40
     public static let typographyLineHeight900: CGFloat = 44
-    public static let typographyLineHeight1000: CGFloat = 114
 
     // MARK: - Letter Spacing (em fraction)
     public static let typographyLetterSpacing000: CGFloat = 0

--- a/Projects/Shared/DesignSystem/Sources/Tokens/Generated/BorderRadius+Generated.swift
+++ b/Projects/Shared/DesignSystem/Sources/Tokens/Generated/BorderRadius+Generated.swift
@@ -13,6 +13,7 @@ public enum BorderRadius {
     public static let borderRadius225: CGFloat = 10
     public static let borderRadius250: CGFloat = 12
     public static let borderRadius300: CGFloat = 16
+    public static let borderRadius350: CGFloat = 20
     public static let borderRadius400: CGFloat = 24
     public static let borderRadius50: CGFloat = 2
     public static let borderRadius500: CGFloat = 32

--- a/Projects/Shared/DesignSystem/Sources/Tokens/Generated/BoxShadow+Generated.swift
+++ b/Projects/Shared/DesignSystem/Sources/Tokens/Generated/BoxShadow+Generated.swift
@@ -27,20 +27,20 @@ public enum BoxShadow {
         offsetY: 4,
         blur: 10,
         spread: 0,
-        color: Color(red: 0, green: 0, blue: 0, opacity: 0.161)
+        color: Color(red: 0, green: 0, blue: 0, opacity: 0.122)
     )
     public static let boxShadow300 = DesignTokenShadow(
         offsetX: 0,
-        offsetY: 2,
+        offsetY: 4,
         blur: 20,
         spread: 0,
-        color: Color(red: 0, green: 0, blue: 0, opacity: 0.2)
+        color: Color(red: 0.169, green: 0.169, blue: 0.169, opacity: 0.122)
     )
     public static let boxShadow400 = DesignTokenShadow(
         offsetX: 0,
-        offsetY: 16,
-        blur: 40,
+        offsetY: 4,
+        blur: 24,
         spread: 0,
-        color: Color(red: 0, green: 0, blue: 0, opacity: 0.2)
+        color: Color(red: 0.169, green: 0.169, blue: 0.169, opacity: 0.122)
     )
 }

--- a/Projects/Shared/DesignSystem/Sources/Tokens/Generated/Sizing+Generated.swift
+++ b/Projects/Shared/DesignSystem/Sources/Tokens/Generated/Sizing+Generated.swift
@@ -8,6 +8,7 @@ import CoreGraphics
 
 public enum Sizing {
     public static let sizing100: CGFloat = 16
+    public static let sizing1000: CGFloat = 280
     public static let sizing150: CGFloat = 20
     public static let sizing200: CGFloat = 24
     public static let sizing300: CGFloat = 32
@@ -16,10 +17,13 @@ public enum Sizing {
     public static let sizing400: CGFloat = 40
     public static let sizing425: CGFloat = 42
     public static let sizing450: CGFloat = 44
+    public static let sizing50: CGFloat = 8
     public static let sizing500: CGFloat = 48
     public static let sizing550: CGFloat = 52
     public static let sizing600: CGFloat = 56
     public static let sizing700: CGFloat = 64
+    public static let sizing75: CGFloat = 12
+    public static let sizing750: CGFloat = 82
     public static let sizing800: CGFloat = 104
     public static let sizing900: CGFloat = 112
 }


### PR DESCRIPTION
## 자동 생성된 디자인 토큰 반영

**Source**: [`zizizoi0709-p/design-tokens@d52f9dcf29a68ef30a9e2b7ebf012affa5957430`](https://github.com/zizizoi0709-p/design-tokens/commit/d52f9dcf29a68ef30a9e2b7ebf012affa5957430)
**Trigger**: `push` on `main`
**Workflow run**: [#5](https://github.com/zizizoi0709-p/design-tokens/actions/runs/26214917586)
**Branch**: `chore/design-tokens-sync-20260521-083306` → `develop`

### 변경된 파일 (베이스: `Projects/Shared/DesignSystem/`)
- `Resources/Colors.xcassets/` (Asset Catalog)
- `Sources/Color/Generated/Colors+Generated.swift`
- `Sources/CustomFont/Generated/Typography+Generated.swift`
- `Sources/Tokens/Generated/Spacing+Generated.swift`
- `Sources/Tokens/Generated/Sizing+Generated.swift`
- `Sources/Tokens/Generated/BorderRadius+Generated.swift`
- `Sources/Tokens/Generated/BorderWidth+Generated.swift`
- `Sources/Tokens/Generated/Opacity+Generated.swift`
- `Sources/Tokens/Generated/BoxShadow+Generated.swift`

### 머지 후 작업
신규 파일이 Xcode 프로젝트에 반영되도록 로컬에서 아래를 실행한다.

```bash
./tuisttool generate && tuist graph
```

> 자동 생성된 PR입니다. 토큰 변경 시마다 새 브랜치/새 PR이 생성되므로
> 머지하지 않은 채로 누적될 수 있습니다. 머지 후엔 브랜치가 자동 삭제됩니다.