### PR TITLE
[HOTFIX] ProfileInputView BottomSheet 컴파일 오류 수정

### DIFF
--- a/Projects/Presentation/AuthFlowFeature/Sources/AuthFlow/AuthFlowFeature.swift
+++ b/Projects/Presentation/AuthFlowFeature/Sources/AuthFlow/AuthFlowFeature.swift
@@ -100,8 +100,8 @@ public struct AuthFlowFeature {
                     if case .departure = state.path[id: id] { return true }
                     return false
                 }
+                guard let id = departureID else { return .none }
                 return .run { send in
-                    guard let id = departureID else { return }
                     await send(.path(.element(id: id, action: .departure(.stationSelected(station)))))
                 }
 

--- a/Projects/Presentation/AuthFlowFeature/Sources/Profile/ProfileInputView.swift
+++ b/Projects/Presentation/AuthFlowFeature/Sources/Profile/ProfileInputView.swift
@@ -101,14 +101,12 @@ public struct ProfileInputView: View {
                 onClose: { store.send(.imagePicker(.dismiss)) }
             ),
             contentVerticalPadding: Spacing.spacing400,
-            buttons: [
-                .init(title: "삭제하기") {
-                    store.send(.imagePicker(.presented(.deleteButtonTapped)))
-                },
-                .init(title: "변경하기") {
-                    store.send(.imagePicker(.presented(.saveButtonTapped)))
-                }
-            ]
+            primaryButton: .init(title: "변경하기") {
+                store.send(.imagePicker(.presented(.saveButtonTapped)))
+            },
+            secondaryButton: .init(title: "삭제하기") {
+                store.send(.imagePicker(.presented(.deleteButtonTapped)))
+            }
         ) {
             if let pickerStore = $store.scope(state: \.imagePicker, action: \.imagePicker).wrappedValue {
                 ProfileImagePickerSheet(store: pickerStore)


### PR DESCRIPTION
## 개요

PR #49에서 `BottomSheet` API를 `buttons: [ButtonConfig]` 배열에서 `primaryButton: ButtonConfig?` / `secondaryButton: ButtonConfig?` 옵셔널 파라미터로 변경하였으나, `ProfileInputView`의 호출부가 누락되어 컴파일 오류가 발생하는 문제를 긴급 수정합니다.

## 변경 사항

- `ProfileInputView`: `buttons: [...]` → `primaryButton:` / `secondaryButton:` 파라미터로 교체
- `AuthFlowFeature`: `guard let`을 `Effect.run` 밖으로 이동하여 departureID가 없을 때 불필요한 Task 생성 방지

## To Reviewer

`ProfileInputView`의 BottomSheet 호출부가 API 변경에서 누락된 부분을 수정하였습니다. `AuthFlowFeature`의 `guard let` 위치 개선도 함께 포함되어 있습니다.

Closes #51