### PR TITLE
[FEAT] 내 장소보기 바텀시트 구현

### DIFF
--- a/Projects/App/Sources/Application/BangawoApp.swift
+++ b/Projects/App/Sources/Application/BangawoApp.swift
@@ -7,13 +7,24 @@ import KakaoSDKCommon
 import NidThirdPartyLogin
 
 import CoreDependencies
+import Entity
 import Presentation
 import Utill
 
 @main
 struct BangawoApp: App {
-    private let store = Store(initialState: RootFeature.State()) {
-        RootFeature()
+    private let store = Store(
+        initialState: MeetingDetailFeature.State(
+            meeting: Meeting(
+                id: UUID(),
+                title: "주말 러닝 모임",
+                hashtag: "#러닝 #건강 #운동",
+                status: .inProgress,
+                participantCount: 5
+            )
+        )
+    ) {
+        MeetingDetailFeature()
     }
 
     init() {
@@ -34,15 +45,17 @@ struct BangawoApp: App {
 
     var body: some Scene {
         WindowGroup {
-            RootView(store: store)
-                .dismissKeyboardOnTap()
-                .onOpenURL { url in
-                    if AuthApi.isKakaoTalkLoginUrl(url) {
-                        AuthController.handleOpenUrl(url: url)
-                    } else if NidOAuth.shared.handleURL(url) {
-                        Log.debug("👤 [Naver] Login callback 처리 완료")
-                    }
+            NavigationStack {
+                MeetingDetailView(store: store)
+            }
+            .dismissKeyboardOnTap()
+            .onOpenURL { url in
+                if AuthApi.isKakaoTalkLoginUrl(url) {
+                    _ = AuthController.handleOpenUrl(url: url)
+                } else if NidOAuth.shared.handleURL(url) {
+                    Log.debug("👤 [Naver] Login callback 처리 완료")
                 }
+            }
         }
     }
 

--- a/Projects/Domain/Entity/Sources/PlaceTag.swift
+++ b/Projects/Domain/Entity/Sources/PlaceTag.swift
@@ -1,0 +1,12 @@
+//
+//  PlaceTag.swift
+//  Entity
+//
+
+public enum PlaceTag: String, Equatable {
+    case reservable = "예약가능"
+    case quiet = "차분한"
+    case goodMood = "분위기 좋은"
+    case parkingAvailable = "주차 가능"
+    case spaciousSeating = "넓은 좌석"
+}

--- a/Projects/Domain/Entity/Sources/PlaceType.swift
+++ b/Projects/Domain/Entity/Sources/PlaceType.swift
@@ -1,0 +1,10 @@
+//
+//  PlaceType.swift
+//  Entity
+//
+
+
+public enum PlaceType: CaseIterable, Equatable, Sendable {
+    case restaurant
+    case cafe
+}

--- a/Projects/Presentation/HomeFeature/Sources/MeetingDetail/MapBottomSheet/MapBottomSheet.swift
+++ b/Projects/Presentation/HomeFeature/Sources/MeetingDetail/MapBottomSheet/MapBottomSheet.swift
@@ -1,0 +1,188 @@
+//
+//  MapBottomSheet.swift
+//  HomeFeature
+//
+
+import SwiftUI
+import DesignSystem
+
+private enum MapBottomSheetMetric {
+    static let handleBarWidth: CGFloat = 36
+    static let handleBarHeight: CGFloat = 4
+    static let handleAreaHeight: CGFloat = 44
+    static let collapsedHeight: CGFloat = 44
+    static let mediumHeightRatio: CGFloat = 0.45
+    static let largeHeightRatio: CGFloat = 0.9
+    static let snapThreshold: CGFloat = 60
+}
+
+struct MapBottomSheet<Content: View>: View {
+    // 시트가 멈출 수 있는 세 단계 높이입니다.
+    private enum Detent {
+        case collapsed // 접혀져 있을 때
+        case medium // 중간 높이
+        case large // 제일 큰 높이
+    }
+
+    private let content: () -> Content
+
+    @State private var detent: Detent = .collapsed
+    // 드래그 중인 거리입니다. onEnded에서 detent 변경과 함께 0으로 되돌립니다.
+    @State private var dragOffset: CGFloat = 0
+
+    init(@ViewBuilder content: @escaping () -> Content) {
+        self.content = content
+    }
+
+    var body: some View {
+        GeometryReader { proxy in
+            let mediumHeight = proxy.size.height * MapBottomSheetMetric.mediumHeightRatio
+            let largeHeight = proxy.size.height * MapBottomSheetMetric.largeHeightRatio
+            let currentOffset = sheetOffset(mediumHeight: mediumHeight, largeHeight: largeHeight)
+
+            VStack {
+                Spacer(minLength: 0)
+
+                // 실제 높이는 large로 고정하고 offset만 바꿔 드래그 중 레이아웃 흔들림을 줄입니다.
+                VStack(spacing: 0) {
+                    MapBottomSheetHandleBar()
+                        .contentShape(Rectangle())
+                        .gesture(dragGesture)
+                        .onTapGesture {
+                            withAnimation(.spring(duration: 0.35)) {
+                                detent = detent == .collapsed ? .medium : .collapsed
+                            }
+                        }
+
+
+                    content()
+                        .padding(.top, Spacing.spacing300)
+                        .opacity(contentOpacity)
+                }
+                .frame(maxWidth: .infinity)
+                .frame(height: largeHeight, alignment: .top)
+                .background(MapBottomSheetBackground())
+                .clipShape(MapBottomSheetShape())
+                .offset(y: currentOffset)
+                .transaction { transaction in
+                    if dragOffset != 0 {
+                        transaction.animation = nil
+                    }
+                }
+            }
+        }
+        .ignoresSafeArea(edges: .bottom)
+    }
+}
+
+private extension MapBottomSheet {
+    var contentOpacity: Double {
+        detent != .collapsed || dragOffset < 0 ? 1 : 0
+    }
+
+    // large 높이의 시트를 아래로 밀어 현재 detent 높이만큼만 보이게 합니다.
+    func sheetOffset(mediumHeight: CGFloat, largeHeight: CGFloat) -> CGFloat {
+        let baseHeight = height(for: detent, mediumHeight: mediumHeight, largeHeight: largeHeight)
+        let visibleHeight = min(max(baseHeight - dragOffset, MapBottomSheetMetric.collapsedHeight), largeHeight)
+        return largeHeight - visibleHeight
+    }
+
+    private func height(for detent: Detent, mediumHeight: CGFloat, largeHeight: CGFloat) -> CGFloat {
+        switch detent {
+        case .collapsed:
+            return MapBottomSheetMetric.collapsedHeight
+        case .medium:
+            return mediumHeight
+        case .large:
+            return largeHeight
+        }
+    }
+
+    var dragGesture: some Gesture {
+        // global 좌표계를 사용해 offset으로 이동 중인 손잡이의 local 좌표 흔들림을 피합니다.
+        DragGesture(coordinateSpace: .global)
+            .onChanged { value in
+                dragOffset = value.translation.height
+            }
+            .onEnded { value in
+                withAnimation(.spring(duration: 0.35)) {
+                    if value.translation.height < -MapBottomSheetMetric.snapThreshold {
+                        detent = nextDetent
+                    } else if value.translation.height > MapBottomSheetMetric.snapThreshold {
+                        detent = previousDetent
+                    }
+                    dragOffset = 0
+                }
+            }
+    }
+
+    private var nextDetent: Detent {
+        switch detent {
+        case .collapsed:
+            return .medium
+        case .medium, .large:
+            return .large
+        }
+    }
+
+    private var previousDetent: Detent {
+        switch detent {
+        case .collapsed, .medium:
+            return .collapsed
+        case .large:
+            return .medium
+        }
+    }
+}
+
+private struct MapBottomSheetHandleBar: View {
+    var body: some View {
+        VStack {
+            RoundedRectangle(cornerRadius: MapBottomSheetMetric.handleBarHeight / 2)
+                .fill(Colors.gray300)
+                .frame(
+                    width: MapBottomSheetMetric.handleBarWidth,
+                    height: MapBottomSheetMetric.handleBarHeight
+                )
+        }
+        .frame(maxWidth: .infinity)
+        .frame(height: MapBottomSheetMetric.handleAreaHeight)
+    }
+}
+
+private struct MapBottomSheetBackground: View {
+    var body: some View {
+        MapBottomSheetShape()
+            .fill(Colors.gray00)
+            .shadow(
+                color: BoxShadow.boxShadow400.color,
+                radius: BoxShadow.boxShadow400.blur,
+                x: BoxShadow.boxShadow400.offsetX,
+                y: BoxShadow.boxShadow400.offsetY
+            )
+    }
+}
+
+private struct MapBottomSheetShape: Shape {
+    func path(in rect: CGRect) -> Path {
+        UnevenRoundedRectangle(
+            topLeadingRadius: BorderRadius.borderRadius400,
+            topTrailingRadius: BorderRadius.borderRadius400
+        )
+        .path(in: rect)
+    }
+}
+
+#Preview {
+    ZStack(alignment: .bottom) {
+        Colors.gray200
+            .ignoresSafeArea()
+
+        MapBottomSheet {
+            VStack(spacing: Spacing.spacing200) {
+                NearbyPlaceRow()
+            }
+            .padding(.horizontal, Spacing.spacing300)
+        }
+    }
+}

--- a/Projects/Presentation/HomeFeature/Sources/MeetingDetail/MapBottomSheet/MapBottomSheet.swift
+++ b/Projects/Presentation/HomeFeature/Sources/MeetingDetail/MapBottomSheet/MapBottomSheet.swift
@@ -6,7 +6,7 @@
 import SwiftUI
 import DesignSystem
 
-private enum MapBottomSheetMetric {
+private enum MapBottomSheetMetric { // 상수 정의
     static let handleBarWidth: CGFloat = 36
     static let handleBarHeight: CGFloat = 4
     static let handleAreaHeight: CGFloat = 44
@@ -15,7 +15,7 @@ private enum MapBottomSheetMetric {
     static let largeHeightRatio: CGFloat = 0.9
     static let snapThreshold: CGFloat = 60
 }
-
+/// 아이폰 하단 노치랑 바텀시트가 겹쳐지는 문제가 있음..
 struct MapBottomSheet<Content: View>: View {
     // 시트가 멈출 수 있는 세 단계 높이입니다.
     private enum Detent {
@@ -56,6 +56,7 @@ struct MapBottomSheet<Content: View>: View {
 
 
                     content()
+                        .frame(maxWidth: .infinity, alignment: .leading)
                         .padding(.top, Spacing.spacing300)
                         .opacity(contentOpacity)
                 }

--- a/Projects/Presentation/HomeFeature/Sources/MeetingDetail/MapBottomSheet/MapBottomSheet.swift
+++ b/Projects/Presentation/HomeFeature/Sources/MeetingDetail/MapBottomSheet/MapBottomSheet.swift
@@ -6,28 +6,47 @@
 import SwiftUI
 import DesignSystem
 
-private enum MapBottomSheetMetric { // 상수 정의
+// MARK: - Metric
+
+private enum MapBottomSheetMetric {
+    /// 사용자가 잡고 드래그할 수 있는 핸들 바의 실제 너비입니다.
     static let handleBarWidth: CGFloat = 36
+    /// 핸들 바 자체의 높이입니다.
     static let handleBarHeight: CGFloat = 4
+    /// 핸들 바 주변 터치 영역 높이입니다. collapsed 상태에서는 이 영역만 노출됩니다.
     static let handleAreaHeight: CGFloat = 44
+    /// 접힌 상태에서 화면에 보이는 시트 높이입니다.
     static let collapsedHeight: CGFloat = 44
+    /// 중간 detent는 전체 화면 높이의 45%를 노출합니다.
+    // TODO: 디테일 한 부분은 추후 수정 필요
     static let mediumHeightRatio: CGFloat = 0.45
+    /// 큰 detent는 전체 화면 높이의 90%를 노출합니다.
     static let largeHeightRatio: CGFloat = 0.9
+    /// 드래그 종료 시 다음/이전 detent로 넘어가기 위한 최소 이동 거리입니다.
     static let snapThreshold: CGFloat = 60
 }
-/// 아이폰 하단 노치랑 바텀시트가 겹쳐지는 문제가 있음..
+
+/// 지도 위에 올라가는 커스텀 바텀시트 컨테이너입니다.
+///
+/// `MapBottomSheet`는 시트의 높이, 드래그, 배경, 스크롤 영역만 담당합니다.
+/// 내부에 들어가는 실제 UI는 `content`로 주입받기 때문에 근처 장소 리스트,
+/// 선택된 장소 상세 등 여러 종류의 시트 내용을 같은 컨테이너에 올릴 수 있습니다.
 struct MapBottomSheet<Content: View>: View {
-    // 시트가 멈출 수 있는 세 단계 높이입니다.
+    /// 시트가 멈출 수 있는 세 단계입니다.
     private enum Detent {
-        case collapsed // 접혀져 있을 때
-        case medium // 중간 높이
-        case large // 제일 큰 높이
+        /// 핸들 영역만 보이는 접힌 상태입니다.
+        case collapsed
+        /// 화면의 일부를 덮는 기본 정보 표시 상태입니다.
+        case medium
+        /// 대부분의 화면을 덮는 확장 상태입니다.
+        case large
     }
 
     private let content: () -> Content
 
+    /// 현재 시트가 머무는 높이 단계입니다.
     @State private var detent: Detent = .collapsed
-    // 드래그 중인 거리입니다. onEnded에서 detent 변경과 함께 0으로 되돌립니다.
+    /// 드래그 중인 임시 이동 거리입니다. 드래그가 끝나면 detent를 갱신하고 0으로 되돌립니다.
     @State private var dragOffset: CGFloat = 0
 
     init(@ViewBuilder content: @escaping () -> Content) {
@@ -40,10 +59,14 @@ struct MapBottomSheet<Content: View>: View {
             let largeHeight = proxy.size.height * MapBottomSheetMetric.largeHeightRatio
             let currentOffset = sheetOffset(mediumHeight: mediumHeight, largeHeight: largeHeight)
 
+            // 시트는 항상 largeHeight 크기로 배치한 뒤 offset으로 아래로 밀어냅니다.
+            // 따라서 실제로 화면에 보이는 높이는 largeHeight - currentOffset입니다.
+            let visibleHeight = largeHeight - currentOffset
+            let contentHeight = max(visibleHeight - MapBottomSheetMetric.handleAreaHeight, 0)
+
             VStack {
                 Spacer(minLength: 0)
 
-                // 실제 높이는 large로 고정하고 offset만 바꿔 드래그 중 레이아웃 흔들림을 줄입니다.
                 VStack(spacing: 0) {
                     MapBottomSheetHandleBar()
                         .contentShape(Rectangle())
@@ -54,11 +77,17 @@ struct MapBottomSheet<Content: View>: View {
                             }
                         }
 
-
-                    content()
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .padding(.top, Spacing.spacing300)
-                        .opacity(contentOpacity)
+                    // 핸들 아래 영역만 스크롤됩니다.
+                    // ScrollView의 높이를 현재 보이는 content 영역에 맞춰야 medium 상태에서도 스크롤이 자연스럽게 동작합니다.
+                    ScrollView(.vertical, showsIndicators: false) {
+                        content()
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(.top, Spacing.spacing300)
+                            .padding(.bottom, 20)
+                    }
+                    .frame(height: contentHeight, alignment: .top)
+                    .scrollDisabled(detent == .collapsed)
+                    .opacity(contentOpacity)
                 }
                 .frame(maxWidth: .infinity)
                 .frame(height: largeHeight, alignment: .top)
@@ -66,6 +95,7 @@ struct MapBottomSheet<Content: View>: View {
                 .clipShape(MapBottomSheetShape())
                 .offset(y: currentOffset)
                 .transaction { transaction in
+                    // 드래그 중에는 offset이 손가락을 즉시 따라가야 하므로 암시적 애니메이션을 끕니다.
                     if dragOffset != 0 {
                         transaction.animation = nil
                     }
@@ -76,18 +106,26 @@ struct MapBottomSheet<Content: View>: View {
     }
 }
 
+// MARK: - Layout
+
 private extension MapBottomSheet {
+    /// collapsed 상태에서는 content가 보이지 않게 숨깁니다.
+    /// 사용자가 위로 드래그하기 시작하면 다음 detent로 확정되기 전에도 content가 자연스럽게 나타납니다.
     var contentOpacity: Double {
         detent != .collapsed || dragOffset < 0 ? 1 : 0
     }
 
-    // large 높이의 시트를 아래로 밀어 현재 detent 높이만큼만 보이게 합니다.
+    /// large 높이의 시트를 아래로 밀어 현재 detent 높이만큼만 보이게 만드는 offset입니다.
+    ///
+    /// 예를 들어 medium 상태라면 시트 자체의 frame은 largeHeight지만,
+    /// `largeHeight - mediumHeight`만큼 아래로 내려 mediumHeight만 화면에 노출합니다.
     func sheetOffset(mediumHeight: CGFloat, largeHeight: CGFloat) -> CGFloat {
         let baseHeight = height(for: detent, mediumHeight: mediumHeight, largeHeight: largeHeight)
         let visibleHeight = min(max(baseHeight - dragOffset, MapBottomSheetMetric.collapsedHeight), largeHeight)
         return largeHeight - visibleHeight
     }
 
+    /// detent별 목표 노출 높이를 반환합니다.
     private func height(for detent: Detent, mediumHeight: CGFloat, largeHeight: CGFloat) -> CGFloat {
         switch detent {
         case .collapsed:
@@ -98,9 +136,16 @@ private extension MapBottomSheet {
             return largeHeight
         }
     }
+}
 
+// MARK: - Gesture
+
+private extension MapBottomSheet {
+    /// 핸들 영역에서만 동작하는 드래그 제스처입니다.
+    ///
+    /// global 좌표계를 사용하면 offset으로 움직이는 시트 내부 local 좌표 변화의 영향을 덜 받아
+    /// 드래그 중 손가락 이동량을 안정적으로 계산할 수 있습니다.
     var dragGesture: some Gesture {
-        // global 좌표계를 사용해 offset으로 이동 중인 손잡이의 local 좌표 흔들림을 피합니다.
         DragGesture(coordinateSpace: .global)
             .onChanged { value in
                 dragOffset = value.translation.height
@@ -117,6 +162,7 @@ private extension MapBottomSheet {
             }
     }
 
+    /// 위로 충분히 드래그했을 때 이동할 다음 단계입니다.
     private var nextDetent: Detent {
         switch detent {
         case .collapsed:
@@ -126,6 +172,7 @@ private extension MapBottomSheet {
         }
     }
 
+    /// 아래로 충분히 드래그했을 때 이동할 이전 단계입니다.
     private var previousDetent: Detent {
         switch detent {
         case .collapsed, .medium:
@@ -135,6 +182,8 @@ private extension MapBottomSheet {
         }
     }
 }
+
+// MARK: - Subviews
 
 private struct MapBottomSheetHandleBar: View {
     var body: some View {

--- a/Projects/Presentation/HomeFeature/Sources/MeetingDetail/MapBottomSheet/MapBottomSheet.swift
+++ b/Projects/Presentation/HomeFeature/Sources/MeetingDetail/MapBottomSheet/MapBottomSheet.swift
@@ -6,6 +6,13 @@
 import SwiftUI
 import DesignSystem
 
+
+// MARK: - Mode
+enum MapBottomSheetMode: Equatable {
+    case resizable // 크기 조절 가능 모드
+    case fixedMedium // 크기 조절 불가 모드
+}
+
 // MARK: - Metric
 
 private enum MapBottomSheetMetric {
@@ -14,14 +21,16 @@ private enum MapBottomSheetMetric {
     /// 핸들 바 자체의 높이입니다.
     static let handleBarHeight: CGFloat = 4
     /// 핸들 바 주변 터치 영역 높이입니다. collapsed 상태에서는 이 영역만 노출됩니다.
-    static let handleAreaHeight: CGFloat = 44
+    static let handleAreaHeight: CGFloat = 38
     /// 접힌 상태에서 화면에 보이는 시트 높이입니다.
-    static let collapsedHeight: CGFloat = 44
-    /// 중간 detent는 전체 화면 높이의 45%를 노출합니다.
+    static let collapsedHeight: CGFloat = 76
+    /// 중간 detent는 324pt 노출합니다.
     // TODO: 디테일 한 부분은 추후 수정 필요
-    static let mediumHeightRatio: CGFloat = 0.45
-    /// 큰 detent는 전체 화면 높이의 90%를 노출합니다.
-    static let largeHeightRatio: CGFloat = 0.9
+    static let mediumHeight: CGFloat = 324
+    /// 고정 모드에서는 376pt를 노출합니다.
+    static let fixedMediumHeight: CGFloat = 376
+    /// 큰 detent는 화면 크기의 91%를 노출합니다.
+    static let largeHeightRatio: CGFloat = 0.91
     /// 드래그 종료 시 다음/이전 detent로 넘어가기 위한 최소 이동 거리입니다.
     static let snapThreshold: CGFloat = 60
 }
@@ -42,22 +51,31 @@ struct MapBottomSheet<Content: View>: View {
         case large
     }
 
+    private let mode: MapBottomSheetMode // 모드 설정
     private let content: () -> Content
 
     /// 현재 시트가 머무는 높이 단계입니다.
     @State private var detent: Detent = .collapsed
     /// 드래그 중인 임시 이동 거리입니다. 드래그가 끝나면 detent를 갱신하고 0으로 되돌립니다.
     @State private var dragOffset: CGFloat = 0
+    
 
-    init(@ViewBuilder content: @escaping () -> Content) {
+    init(mode: MapBottomSheetMode = .resizable, @ViewBuilder content: @escaping () -> Content) {
+        self.mode = mode
         self.content = content
     }
 
     var body: some View {
         GeometryReader { proxy in
-            let mediumHeight = proxy.size.height * MapBottomSheetMetric.mediumHeightRatio
             let largeHeight = proxy.size.height * MapBottomSheetMetric.largeHeightRatio
-            let currentOffset = sheetOffset(mediumHeight: mediumHeight, largeHeight: largeHeight)
+            let mediumHeight = min(MapBottomSheetMetric.mediumHeight, largeHeight)
+            let fixedMediumHeight = min(MapBottomSheetMetric.fixedMediumHeight, largeHeight)
+            let effectiveDetent: Detent = mode == .fixedMedium ? .medium : detent
+            let currentOffset = sheetOffset(
+                for: effectiveDetent,
+                mediumHeight: mode == .fixedMedium ? fixedMediumHeight : mediumHeight,
+                largeHeight: largeHeight
+            )
 
             // 시트는 항상 largeHeight 크기로 배치한 뒤 offset으로 아래로 밀어냅니다.
             // 따라서 실제로 화면에 보이는 높이는 largeHeight - currentOffset입니다.
@@ -72,6 +90,8 @@ struct MapBottomSheet<Content: View>: View {
                         .contentShape(Rectangle())
                         .gesture(dragGesture)
                         .onTapGesture {
+                            guard mode == .resizable else { return }
+
                             withAnimation(.spring(duration: 0.35)) {
                                 detent = detent == .collapsed ? .medium : .collapsed
                             }
@@ -82,12 +102,11 @@ struct MapBottomSheet<Content: View>: View {
                     ScrollView(.vertical, showsIndicators: false) {
                         content()
                             .frame(maxWidth: .infinity, alignment: .leading)
-                            .padding(.top, Spacing.spacing300)
                             .padding(.bottom, 20)
                     }
                     .frame(height: contentHeight, alignment: .top)
-                    .scrollDisabled(detent == .collapsed)
-                    .opacity(contentOpacity)
+                    .scrollDisabled(effectiveDetent == .collapsed)
+                    //.opacity(contentOpacity)
                 }
                 .frame(maxWidth: .infinity)
                 .frame(height: largeHeight, alignment: .top)
@@ -119,7 +138,7 @@ private extension MapBottomSheet {
     ///
     /// 예를 들어 medium 상태라면 시트 자체의 frame은 largeHeight지만,
     /// `largeHeight - mediumHeight`만큼 아래로 내려 mediumHeight만 화면에 노출합니다.
-    func sheetOffset(mediumHeight: CGFloat, largeHeight: CGFloat) -> CGFloat {
+    private func sheetOffset(for detent: Detent, mediumHeight: CGFloat, largeHeight: CGFloat) -> CGFloat {
         let baseHeight = height(for: detent, mediumHeight: mediumHeight, largeHeight: largeHeight)
         let visibleHeight = min(max(baseHeight - dragOffset, MapBottomSheetMetric.collapsedHeight), largeHeight)
         return largeHeight - visibleHeight
@@ -148,9 +167,12 @@ private extension MapBottomSheet {
     var dragGesture: some Gesture {
         DragGesture(coordinateSpace: .global)
             .onChanged { value in
+                guard mode == .resizable else { return }
                 dragOffset = value.translation.height
             }
             .onEnded { value in
+                guard mode == .resizable else { return }
+
                 withAnimation(.spring(duration: 0.35)) {
                     if value.translation.height < -MapBottomSheetMetric.snapThreshold {
                         detent = nextDetent
@@ -223,14 +245,27 @@ private struct MapBottomSheetShape: Shape {
     }
 }
 
+/*
+나중에 지도 붙이면 이런식으로 사용하면 좋을듯
+ MapBottomSheet(
+mode: store.selectedPlace == nil ? .resizable : .fixedMedium
+) {
+if store.selectedPlace == nil {
+    NearbyPlaceListSheet(...)
+} else {
+    SelectedPlaceDetailSheet()
+}
+}
+*/
+
 #Preview {
     ZStack(alignment: .bottom) {
         Colors.gray200
             .ignoresSafeArea()
 
-        MapBottomSheet {
-            VStack(spacing: Spacing.spacing200) {
-                NearbyPlaceRow()
+        MapBottomSheet(mode: .fixedMedium) {
+            VStack(spacing: Spacing.spacing100) {
+                SelectedPlaceDetailSheet()
             }
             .padding(.horizontal, Spacing.spacing300)
         }

--- a/Projects/Presentation/HomeFeature/Sources/MeetingDetail/MapBottomSheet/NearbyPlace/NearbyPlaceListSheet.swift
+++ b/Projects/Presentation/HomeFeature/Sources/MeetingDetail/MapBottomSheet/NearbyPlace/NearbyPlaceListSheet.swift
@@ -1,0 +1,130 @@
+//
+//  NearbyPlaceListSheet.swift
+//  HomeFeature
+//
+
+import SwiftUI
+import ComposableArchitecture
+import DesignSystem
+
+/// 역근처 정보 리스트 보여줄 시트
+struct NearbyPlaceListSheet: View {
+    private let store: StoreOf<NearbyPlaceListSheetFeature>
+
+    init(store: StoreOf<NearbyPlaceListSheetFeature>) {
+        self.store = store
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Spacing.spacing200) {
+            Text("신사역")
+                .pretendardCustomFont(textStyle: .headingSmall)
+                .foregroundStyle(Colors.gray900)
+
+            NearbyPlaceCategoryFilter(
+                selectedCategory: store.selectedCategory,
+                onCategoryTapped: { store.send(.categoryTapped($0)) }
+            )
+
+            NearbyPlaceOptionFilter(
+                isParkingAvailableSelected: store.isParkingAvailableSelected,
+                isReservableSelected: store.isReservableSelected,
+                onParkingAvailableTapped: { store.send(.parkingAvailableFilterTapped) },
+                onReservableTapped: { store.send(.reservableFilterTapped) }
+            )
+
+            NearbyPlaceRow()
+            NearbyPlaceRow()
+            NearbyPlaceRow()
+            NearbyPlaceRow()
+            NearbyPlaceRow()
+        }
+        .padding(.horizontal, Spacing.spacing400)
+    }
+}
+
+private struct NearbyPlaceCategoryFilter: View {
+    let selectedCategory: NearbyPlaceCategory
+    let onCategoryTapped: (NearbyPlaceCategory) -> Void
+
+    var body: some View {
+        HStack(spacing: Spacing.spacing200) {
+            ForEach(NearbyPlaceCategory.allCases, id: \.self) { category in
+                NearbyPlaceCategoryChip(
+                    title: category.title,
+                    isSelected: selectedCategory == category
+                ) {
+                    onCategoryTapped(category)
+                }
+            }
+        }
+    }
+}
+
+private struct NearbyPlaceOptionFilter: View {
+    let isParkingAvailableSelected: Bool
+    let isReservableSelected: Bool
+    let onParkingAvailableTapped: () -> Void
+    let onReservableTapped: () -> Void
+
+    var body: some View {
+        HStack(spacing: Spacing.spacing300) {
+            NearbyPlaceOptionFilterButton(
+                title: "주차 가능",
+                isSelected: isParkingAvailableSelected,
+                onTap: onParkingAvailableTapped
+            )
+
+            NearbyPlaceOptionFilterButton(
+                title: "예약 가능",
+                isSelected: isReservableSelected,
+                onTap: onReservableTapped
+            )
+        }
+    }
+}
+
+private struct NearbyPlaceCategoryChip: View {
+    let title: String
+    let isSelected: Bool
+    let onTap: () -> Void
+
+    var body: some View {
+        Button(action: onTap) {
+            Text(title)
+                .pretendardCustomFont(textStyle: .bodyMedium)
+                .foregroundStyle(isSelected ? Colors.gray00 : Colors.gray700)
+                .padding(.horizontal, Spacing.spacing250)
+                .padding(.vertical, Spacing.spacing150)
+                .background(
+                    Capsule()
+                        .fill(isSelected ? Colors.red500 : Colors.gray100)
+                )
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+private struct NearbyPlaceOptionFilterButton: View {
+    let title: String
+    let isSelected: Bool
+    let onTap: () -> Void
+
+    var body: some View {
+        Button(action: onTap) {
+            HStack(spacing: Spacing.spacing100) {
+                Checkbox(
+                    variant: .ghost,
+                    state: isSelected ? .enabled : .disabled,
+                    size: .small
+                )
+
+                Text(title)
+                    .pretendardCustomFont(textStyle: .bodyMedium)
+                    .foregroundStyle(Colors.gray700)
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+}

--- a/Projects/Presentation/HomeFeature/Sources/MeetingDetail/MapBottomSheet/NearbyPlace/NearbyPlaceListSheet.swift
+++ b/Projects/Presentation/HomeFeature/Sources/MeetingDetail/MapBottomSheet/NearbyPlace/NearbyPlaceListSheet.swift
@@ -3,9 +3,9 @@
 //  HomeFeature
 //
 
-import SwiftUI
 import ComposableArchitecture
 import DesignSystem
+import SwiftUI
 
 /// 역근처 정보 리스트 보여줄 시트
 struct NearbyPlaceListSheet: View {
@@ -20,6 +20,7 @@ struct NearbyPlaceListSheet: View {
             Text("신사역")
                 .pretendardCustomFont(textStyle: .headingSmall)
                 .foregroundStyle(Colors.gray900)
+                .padding(.horizontal, Spacing.spacing400)
 
             NearbyPlaceCategoryFilter(
                 selectedCategory: store.selectedCategory,
@@ -32,14 +33,17 @@ struct NearbyPlaceListSheet: View {
                 onParkingAvailableTapped: { store.send(.parkingAvailableFilterTapped) },
                 onReservableTapped: { store.send(.reservableFilterTapped) }
             )
-
-            NearbyPlaceRow()
-            NearbyPlaceRow()
-            NearbyPlaceRow()
-            NearbyPlaceRow()
-            NearbyPlaceRow()
+            .padding(.horizontal, Spacing.spacing400)
+            
+            Group {
+                NearbyPlaceRow()
+                NearbyPlaceRow()
+                NearbyPlaceRow()
+                NearbyPlaceRow()
+                NearbyPlaceRow()
+            }
+            .padding(.horizontal, Spacing.spacing400)
         }
-        .padding(.horizontal, Spacing.spacing400)
     }
 }
 
@@ -48,15 +52,24 @@ private struct NearbyPlaceCategoryFilter: View {
     let onCategoryTapped: (NearbyPlaceCategory) -> Void
 
     var body: some View {
-        HStack(spacing: Spacing.spacing200) {
-            ForEach(NearbyPlaceCategory.allCases, id: \.self) { category in
-                NearbyPlaceCategoryChip(
-                    title: category.title,
-                    isSelected: selectedCategory == category
-                ) {
-                    onCategoryTapped(category)
+        VStack(spacing: 0) {
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: Spacing.spacing200) {
+                    ForEach(NearbyPlaceCategory.allCases, id: \.self) { category in
+                        NearbyPlaceCategoryChip(
+                            title: category.title,
+                            isSelected: selectedCategory == category
+                        ) {
+                            onCategoryTapped(category)
+                        }
+                    }
                 }
+                .padding(.horizontal, Spacing.spacing400)
             }
+
+            Rectangle()
+                .fill(Colors.gray200)
+                .frame(height: 1)
         }
     }
 }
@@ -91,17 +104,30 @@ private struct NearbyPlaceCategoryChip: View {
 
     var body: some View {
         Button(action: onTap) {
-            Text(title)
-                .pretendardCustomFont(textStyle: .bodyMedium)
-                .foregroundStyle(isSelected ? Colors.gray00 : Colors.gray700)
-                .padding(.horizontal, Spacing.spacing250)
-                .padding(.vertical, Spacing.spacing150)
-                .background(
-                    Capsule()
-                        .fill(isSelected ? Colors.red500 : Colors.gray100)
-                )
+            VStack(spacing: Spacing.spacing150) {
+                Text(title)
+                    .pretendardCustomFont(textStyle: isSelected ? .bodyMediumEmphasized : .bodyMedium)
+                    .foregroundStyle(isSelected ? Colors.gray900 : Colors.gray700)
+                    .padding(.horizontal, Spacing.spacing250)
+
+                TopRoundedRectangle(cornerRadius: 2)
+                    .fill(isSelected ? Colors.gray900 : Color.clear)
+                    .frame(height: 2)
+            }
         }
         .buttonStyle(.plain)
+    }
+}
+
+private struct TopRoundedRectangle: Shape { // 카테고리 선택 시 underline shape
+    let cornerRadius: CGFloat
+
+    func path(in rect: CGRect) -> Path {
+        UnevenRoundedRectangle(
+            topLeadingRadius: cornerRadius,
+            topTrailingRadius: cornerRadius
+        )
+        .path(in: rect)
     }
 }
 
@@ -123,6 +149,16 @@ private struct NearbyPlaceOptionFilterButton: View {
                     .pretendardCustomFont(textStyle: .bodyMedium)
                     .foregroundStyle(Colors.gray700)
             }
+            .padding(.horizontal, Spacing.spacing250)
+            .padding(.vertical, Spacing.spacing150)
+            .background(
+                RoundedRectangle(cornerRadius: BorderRadius.borderRadius400)
+                    .fill(Colors.gray100)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: BorderRadius.borderRadius400)
+                    .stroke(Colors.gray200, lineWidth: 1)
+            )
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)

--- a/Projects/Presentation/HomeFeature/Sources/MeetingDetail/MapBottomSheet/NearbyPlace/NearbyPlaceListSheet.swift
+++ b/Projects/Presentation/HomeFeature/Sources/MeetingDetail/MapBottomSheet/NearbyPlace/NearbyPlaceListSheet.swift
@@ -16,16 +16,19 @@ struct NearbyPlaceListSheet: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: Spacing.spacing200) {
+        VStack(alignment: .leading, spacing: 0) {
             Text("신사역")
-                .pretendardCustomFont(textStyle: .headingSmall)
+                .pretendardCustomFont(textStyle: .titleLarge)
                 .foregroundStyle(Colors.gray900)
                 .padding(.horizontal, Spacing.spacing400)
+                .padding(.bottom, Spacing.spacing250)
 
             NearbyPlaceCategoryFilter(
                 selectedCategory: store.selectedCategory,
                 onCategoryTapped: { store.send(.categoryTapped($0)) }
             )
+            .padding(.top, Spacing.spacing250)
+            .padding(.bottom, Spacing.spacing300)
 
             NearbyPlaceOptionFilter(
                 isParkingAvailableSelected: store.isParkingAvailableSelected,
@@ -34,6 +37,7 @@ struct NearbyPlaceListSheet: View {
                 onReservableTapped: { store.send(.reservableFilterTapped) }
             )
             .padding(.horizontal, Spacing.spacing400)
+            .padding(.bottom, Spacing.spacing250)
             
             Group {
                 NearbyPlaceRow()
@@ -42,7 +46,6 @@ struct NearbyPlaceListSheet: View {
                 NearbyPlaceRow()
                 NearbyPlaceRow()
             }
-            .padding(.horizontal, Spacing.spacing400)
         }
     }
 }
@@ -81,7 +84,7 @@ private struct NearbyPlaceOptionFilter: View {
     let onReservableTapped: () -> Void
 
     var body: some View {
-        HStack(spacing: Spacing.spacing300) {
+        HStack(spacing: Spacing.spacing200) {
             NearbyPlaceOptionFilterButton(
                 title: "주차 가능",
                 isSelected: isParkingAvailableSelected,
@@ -146,18 +149,18 @@ private struct NearbyPlaceOptionFilterButton: View {
                 )
 
                 Text(title)
-                    .pretendardCustomFont(textStyle: .bodyMedium)
-                    .foregroundStyle(Colors.gray700)
+                    .pretendardCustomFont(textStyle: .labelSmall)
+                    .foregroundStyle(Colors.gray800)
             }
             .padding(.horizontal, Spacing.spacing250)
             .padding(.vertical, Spacing.spacing150)
             .background(
                 RoundedRectangle(cornerRadius: BorderRadius.borderRadius400)
-                    .fill(Colors.gray100)
+                    .fill(isSelected ? Colors.grayAlpha100 : Colors.gray00)
             )
             .overlay(
                 RoundedRectangle(cornerRadius: BorderRadius.borderRadius400)
-                    .stroke(Colors.gray200, lineWidth: 1)
+                    .stroke(Colors.gray300, lineWidth: 1)
             )
             .contentShape(Rectangle())
         }

--- a/Projects/Presentation/HomeFeature/Sources/MeetingDetail/MapBottomSheet/NearbyPlace/NearbyPlaceListSheetFeature.swift
+++ b/Projects/Presentation/HomeFeature/Sources/MeetingDetail/MapBottomSheet/NearbyPlace/NearbyPlaceListSheetFeature.swift
@@ -1,0 +1,56 @@
+//
+//  NearbyPlaceListSheetFeature.swift
+//  HomeFeature
+//
+
+import ComposableArchitecture
+import Utill
+
+public enum NearbyPlaceCategory: String, CaseIterable, Equatable, Sendable {
+    case all = "전체"
+    case cafe = "카페"
+    case restaurant = "음식점"
+
+    var title: String { rawValue }
+}
+
+@Reducer
+public struct NearbyPlaceListSheetFeature {
+    @ObservableState
+    public struct State: Equatable {
+        public var selectedCategory: NearbyPlaceCategory = .all // 카테고리
+        public var isParkingAvailableSelected = false // 주차 가능 여부
+        public var isReservableSelected = false // 예약 가능여부
+
+        public init() {}
+    }
+
+    public enum Action: Equatable {
+        case categoryTapped(NearbyPlaceCategory)
+        case parkingAvailableFilterTapped
+        case reservableFilterTapped
+    }
+
+    public init() {}
+
+    public var body: some ReducerOf<Self> {
+        Reduce { state, action in
+            switch action {
+            case .categoryTapped(let category):
+                state.selectedCategory = category
+                Log.debug("역근처 장소 카테고리 선택: \(category.title)")
+                return .none
+
+            case .parkingAvailableFilterTapped:
+                state.isParkingAvailableSelected.toggle()
+                Log.debug("역근처 장소 주차 가능 필터: \(state.isParkingAvailableSelected ? "선택" : "해제")")
+                return .none
+
+            case .reservableFilterTapped:
+                state.isReservableSelected.toggle()
+                Log.debug("역근처 장소 예약 가능 필터: \(state.isReservableSelected ? "선택" : "해제")")
+                return .none
+            }
+        }
+    }
+}

--- a/Projects/Presentation/HomeFeature/Sources/MeetingDetail/MapBottomSheet/NearbyPlace/NearbyPlaceListSheetFeature.swift
+++ b/Projects/Presentation/HomeFeature/Sources/MeetingDetail/MapBottomSheet/NearbyPlace/NearbyPlaceListSheetFeature.swift
@@ -9,7 +9,11 @@ import Utill
 public enum NearbyPlaceCategory: String, CaseIterable, Equatable, Sendable {
     case all = "전체"
     case cafe = "카페"
-    case restaurant = "음식점"
+    case desert = "디저트"
+    case koreaFood = "한식"
+    case japaneseFood = "일식"
+    case snackBar = "분식"
+    case asianFood = "아시안"
 
     var title: String { rawValue }
 }

--- a/Projects/Presentation/HomeFeature/Sources/MeetingDetail/MapBottomSheet/NearbyPlace/NearbyPlaceRow.swift
+++ b/Projects/Presentation/HomeFeature/Sources/MeetingDetail/MapBottomSheet/NearbyPlace/NearbyPlaceRow.swift
@@ -27,6 +27,8 @@ struct NearbyPlaceRow: View {
 
                 VStack(alignment: .leading, spacing: Spacing.spacing200) {
                     Text("이름")
+                        .pretendardCustomFont(textStyle: .bodyLargeEmphasized)
+                        .foregroundStyle(Color.gray800)
 
                     HStack(spacing: Spacing.spacing225) {
                         Text("18km")
@@ -74,6 +76,8 @@ struct NearbyPlaceRow: View {
         }
         // 툴팁이 열린 row 전체를 형제 row보다 위에 올려, 아래 row 텍스트가 툴팁 위로 노출되지 않게 합니다.
         .zIndex(isTooltipLayerElevated ? 1 : 0)
+        .padding(.horizontal, Spacing.spacing400)
+        .padding(.vertical, Spacing.spacing300)
     }
 }
 
@@ -115,15 +119,21 @@ private struct NearbyPlaceAddressTooltip: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: Spacing.spacing200) {
-            AddressTooltipRow(title: "도로명", address: roadAddress)
-            AddressTooltipRow(title: "지번", address: lotAddress)
+            PlaceAddressRow(title: "도로명", address: roadAddress)
+            PlaceAddressRow(title: "지번", address: lotAddress)
         }
         .padding(.horizontal, Spacing.spacing250)
         .padding(.vertical, Spacing.spacing200)
         .frame(width: tooltipWidth, alignment: .leading)
         .background(
             RoundedRectangle(cornerRadius: BorderRadius.borderRadius200)
-                .fill(Colors.gray100)
+                .fill(Colors.gray00)
+                .shadow(
+                    color: BoxShadow.boxShadow200.color,
+                    radius: BoxShadow.boxShadow200.blur,
+                    x: BoxShadow.boxShadow200.offsetX,
+                    y: BoxShadow.boxShadow200.offsetY
+                )
         )
     }
 }
@@ -140,54 +150,6 @@ private extension NearbyPlaceAddressTooltip {
 
 }
 
-private struct AddressTooltipRow: View {
-    let title: String
-    let address: String
-
-    var body: some View {
-        HStack(spacing: Spacing.spacing150) {
-            AddressTypeBadge(title: title)
-
-            Text(address)
-                .pretendardCustomFont(textStyle: .labelSmall)
-                .foregroundStyle(Colors.gray700)
-                .lineLimit(1)
-                .truncationMode(.tail)
-
-            Button {
-                UIPasteboard.general.string = address
-            } label: {
-                HStack(spacing: Spacing.spacing50) {
-                    Image(assetName: "ic_copy_16")
-                        .renderingMode(.template)
-                        .frame(width: 16, height: 16)
-                }
-                .foregroundStyle(Colors.gray600)
-            }
-            .buttonStyle(.plain)
-        }
-    }
-}
-
-private struct AddressTypeBadge: View {
-    let title: String
-
-    var body: some View {
-        Text(title)
-            .pretendardCustomFont(textStyle: .labelSmallEmphasized)
-            .foregroundStyle(Colors.gray800)
-            .padding(.horizontal, Spacing.spacing150)
-            .padding(.vertical, Spacing.spacing50)
-            .background(
-                RoundedRectangle(cornerRadius: BorderRadius.borderRadius150)
-                    .fill(Colors.gray00)
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: BorderRadius.borderRadius150)
-                    .stroke(Colors.gray200, lineWidth: 1)
-            )
-    }
-}
 
 // MARK: - Thumbnail
 

--- a/Projects/Presentation/HomeFeature/Sources/MeetingDetail/MapBottomSheet/NearbyPlace/NearbyPlaceRow.swift
+++ b/Projects/Presentation/HomeFeature/Sources/MeetingDetail/MapBottomSheet/NearbyPlace/NearbyPlaceRow.swift
@@ -13,6 +13,11 @@ import UIKit
 struct NearbyPlaceRow: View {
     // TODO: data 서버 모델로 변경 필요
     @State private var isTooltipPresented = false
+    @State private var isTooltipLayerElevated = false
+    @State private var addressWidth: CGFloat = 0
+
+    private let displayAddress = "서울 강남구 역삼동"
+    private let tooltipAnimationDuration = 0.2
 
     var body: some View {
         VStack(spacing: 0) {
@@ -24,32 +29,36 @@ struct NearbyPlaceRow: View {
                         Text("18km")
                             .pretendardCustomFont(textStyle: .bodyMedium)
                             .foregroundStyle(Color.gray600)
-                        HStack(spacing: Spacing.spacing100) {
-                            Text("서울 강남구 역삼동")
-                                .pretendardCustomFont(textStyle: .bodyMedium)
-                                .foregroundStyle(Color.gray700)
+                        Button {
+                            toggleTooltip()
+                        } label: {
+                            HStack(spacing: Spacing.spacing100) {
+                                Text(displayAddress)
+                                    .pretendardCustomFont(textStyle: .bodyMedium)
+                                    .foregroundStyle(Color.gray700)
+                                    .background(
+                                        GeometryReader { proxy in
+                                            Color.clear.preference(
+                                                key: AddressWidthPreferenceKey.self,
+                                                value: proxy.size.width
+                                            )
+                                        }
+                                    )
 
-                            Button {
-                                withAnimation(.easeInOut(duration: 0.2)) {
-                                    isTooltipPresented.toggle()
-                                }
-                            } label: {
                                 Image(assetName: "ic_arrow_small_down_16")
                                     .renderingMode(.template)
                                     .foregroundStyle(Colors.gray500)
                                     .frame(width: 16, height: 16)
+                                    .rotationEffect(.degrees(isTooltipPresented ? 180 : 0))
+                                    .animation(.easeInOut(duration: tooltipAnimationDuration), value: isTooltipPresented)
                             }
-                            .buttonStyle(.plain)
-                            .accessibilityLabel("주소 안내 보기")
+                            .contentShape(Rectangle())
                         }
-                        .overlay(alignment: .bottomLeading) {
-                            if isTooltipPresented {
-                                NearbyPlaceAddressTooltip()
-                                    .offset(y: 32)
-                                    .transition(.opacity.combined(with: .move(edge: .bottom)))
-                            }
+                        .buttonStyle(.plain)
+                        .accessibilityLabel("주소 안내 보기")
+                        .onPreferenceChange(AddressWidthPreferenceKey.self) { width in
+                            addressWidth = width
                         }
-                        .zIndex(1)
                     }
                     .zIndex(1)
 
@@ -61,12 +70,52 @@ struct NearbyPlaceRow: View {
                     }
                     .zIndex(0)
                 }
+                .overlay(alignment: .bottomLeading) {
+                    if isTooltipPresented {
+                        NearbyPlaceAddressTooltip(minimumWidth: addressWidth)
+                            .offset(y: Spacing.spacing600)
+                            .transition(.opacity.combined(with: .scale(scale: 0.96, anchor: .top)))
+                    }
+                }
+                .zIndex(1)
+            }
+        }
+        .zIndex(isTooltipLayerElevated ? 1 : 0)
+    }
+}
+
+private extension NearbyPlaceRow {
+    func toggleTooltip() {
+        if isTooltipPresented {
+            withAnimation(.easeInOut(duration: tooltipAnimationDuration)) {
+                isTooltipPresented = false
+            }
+
+            DispatchQueue.main.asyncAfter(deadline: .now() + tooltipAnimationDuration) {
+                if !isTooltipPresented {
+                    isTooltipLayerElevated = false
+                }
+            }
+        } else {
+            isTooltipLayerElevated = true
+            withAnimation(.easeInOut(duration: tooltipAnimationDuration)) {
+                isTooltipPresented = true
             }
         }
     }
 }
 
+private struct AddressWidthPreferenceKey: PreferenceKey {
+    static let defaultValue: CGFloat = 0
+
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = nextValue()
+    }
+}
+
 private struct NearbyPlaceAddressTooltip: View {
+    let minimumWidth: CGFloat
+
     private let roadAddress = "서울 강남구 테헤란로 123"
     private let lotAddress = "서울 강남구 역삼동 123-45"
 
@@ -77,6 +126,8 @@ private struct NearbyPlaceAddressTooltip: View {
         }
         .padding(.horizontal, Spacing.spacing250)
         .padding(.vertical, Spacing.spacing200)
+        .frame(minWidth: minimumWidth, alignment: .leading)
+        .fixedSize(horizontal: true, vertical: false)
         .background(
             RoundedRectangle(cornerRadius: BorderRadius.borderRadius200)
                 .fill(Colors.gray100)
@@ -94,6 +145,8 @@ private extension NearbyPlaceAddressTooltip {
             Text(address)
                 .pretendardCustomFont(textStyle: .labelSmall)
                 .foregroundStyle(Colors.gray700)
+                .lineLimit(1)
+                .truncationMode(.tail)
 
             Button {
                 UIPasteboard.general.string = address

--- a/Projects/Presentation/HomeFeature/Sources/MeetingDetail/MapBottomSheet/NearbyPlace/NearbyPlaceRow.swift
+++ b/Projects/Presentation/HomeFeature/Sources/MeetingDetail/MapBottomSheet/NearbyPlace/NearbyPlaceRow.swift
@@ -8,13 +8,14 @@ import Entity
 import SwiftUI
 import UIKit
 
-// 역근처 장소 리스트 뷰에 들어갈 UI
-
+/// 역 근처 장소 리스트에 들어가는 단일 장소 row입니다.
+///
+/// 현재는 서버 모델이 연결되기 전 단계라 장소명, 주소, 태그, 이미지가 더미 값으로 구성되어 있습니다.
+/// 주소 영역을 누르면 도로명/지번 주소를 보여주는 툴팁이 열리고, 툴팁은 row 위계보다 높은 레이어에 표시됩니다.
 struct NearbyPlaceRow: View {
-    // TODO: data 서버 모델로 변경 필요
+    // TODO: 서버 장소 모델이 확정되면 더미 값 대신 실제 place 데이터를 주입받도록 변경합니다.
     @State private var isTooltipPresented = false
     @State private var isTooltipLayerElevated = false
-    @State private var addressWidth: CGFloat = 0
 
     private let displayAddress = "서울 강남구 역삼동"
     private let tooltipAnimationDuration = 0.2
@@ -23,12 +24,15 @@ struct NearbyPlaceRow: View {
         VStack(spacing: 0) {
             HStack(alignment: .top, spacing: Spacing.spacing300) {
                 NearbyPlaceThumbnail()
+
                 VStack(alignment: .leading, spacing: Spacing.spacing200) {
                     Text("이름")
+
                     HStack(spacing: Spacing.spacing225) {
                         Text("18km")
                             .pretendardCustomFont(textStyle: .bodyMedium)
                             .foregroundStyle(Color.gray600)
+
                         Button {
                             toggleTooltip()
                         } label: {
@@ -36,14 +40,6 @@ struct NearbyPlaceRow: View {
                                 Text(displayAddress)
                                     .pretendardCustomFont(textStyle: .bodyMedium)
                                     .foregroundStyle(Color.gray700)
-                                    .background(
-                                        GeometryReader { proxy in
-                                            Color.clear.preference(
-                                                key: AddressWidthPreferenceKey.self,
-                                                value: proxy.size.width
-                                            )
-                                        }
-                                    )
 
                                 Image(assetName: "ic_arrow_small_down_16")
                                     .renderingMode(.template)
@@ -56,9 +52,6 @@ struct NearbyPlaceRow: View {
                         }
                         .buttonStyle(.plain)
                         .accessibilityLabel("주소 안내 보기")
-                        .onPreferenceChange(AddressWidthPreferenceKey.self) { width in
-                            addressWidth = width
-                        }
                     }
                     .zIndex(1)
 
@@ -66,25 +59,32 @@ struct NearbyPlaceRow: View {
                         PlaceTagChip(tag: .reservable)
                         PlaceTagChip(tag: .spaciousSeating)
                         PlaceTagChip(tag: .parkingAvailable)
-
                     }
                     .zIndex(0)
                 }
-                .overlay(alignment: .bottomLeading) {
-                    if isTooltipPresented {
-                        NearbyPlaceAddressTooltip(minimumWidth: addressWidth)
-                            .offset(y: Spacing.spacing600)
-                            .transition(.opacity.combined(with: .scale(scale: 0.96, anchor: .top)))
-                    }
-                }
                 .zIndex(1)
             }
+            .overlay(alignment: .bottomLeading) {
+                if isTooltipPresented {
+                    NearbyPlaceAddressTooltip()
+                        .offset(y: Spacing.spacing600)
+                        .transition(.opacity.combined(with: .scale(scale: 0.96, anchor: .top)))
+                }
+            }
         }
+        // 툴팁이 열린 row 전체를 형제 row보다 위에 올려, 아래 row 텍스트가 툴팁 위로 노출되지 않게 합니다.
         .zIndex(isTooltipLayerElevated ? 1 : 0)
     }
 }
 
+// MARK: - Tooltip State
+
 private extension NearbyPlaceRow {
+    /// 주소 툴팁을 열고 닫습니다.
+    ///
+    /// 닫힐 때 바로 zIndex를 내리면 사라지는 애니메이션이 아래 row 뒤로 묻힐 수 있습니다.
+    /// 그래서 표시 상태(`isTooltipPresented`)와 레이어 상태(`isTooltipLayerElevated`)를 분리하고,
+    /// 닫힘 애니메이션이 끝난 뒤에만 row 레이어를 원래 위치로 되돌립니다.
     func toggleTooltip() {
         if isTooltipPresented {
             withAnimation(.easeInOut(duration: tooltipAnimationDuration)) {
@@ -105,29 +105,22 @@ private extension NearbyPlaceRow {
     }
 }
 
-private struct AddressWidthPreferenceKey: PreferenceKey {
-    static let defaultValue: CGFloat = 0
-
-    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
-        value = nextValue()
-    }
-}
+// MARK: - Address Tooltip
 
 private struct NearbyPlaceAddressTooltip: View {
-    let minimumWidth: CGFloat
-
+    /// 화면 좌우에서 각각 20pt 떨어진 폭으로 툴팁을 맞춥니다.
+    private let horizontalMargin: CGFloat = 20
     private let roadAddress = "서울 강남구 테헤란로 123"
     private let lotAddress = "서울 강남구 역삼동 123-45"
 
     var body: some View {
         VStack(alignment: .leading, spacing: Spacing.spacing200) {
-            addressTooltipRow(title: "도로명", address: roadAddress)
-            addressTooltipRow(title: "지번", address: lotAddress)
+            AddressTooltipRow(title: "도로명", address: roadAddress)
+            AddressTooltipRow(title: "지번", address: lotAddress)
         }
         .padding(.horizontal, Spacing.spacing250)
         .padding(.vertical, Spacing.spacing200)
-        .frame(minWidth: minimumWidth, alignment: .leading)
-        .fixedSize(horizontal: true, vertical: false)
+        .frame(width: tooltipWidth, alignment: .leading)
         .background(
             RoundedRectangle(cornerRadius: BorderRadius.borderRadius200)
                 .fill(Colors.gray100)
@@ -136,11 +129,24 @@ private struct NearbyPlaceAddressTooltip: View {
 }
 
 private extension NearbyPlaceAddressTooltip {
-    func addressTooltipRow(title: String, address: String) -> some View {
+    /// `UIScreen.main`은 iOS 26에서 deprecated이므로 현재 연결된 window scene의 screen을 사용합니다.
+    var tooltipWidth: CGFloat {
+        let screenWidth = UIApplication.shared.connectedScenes
+            .compactMap { ($0 as? UIWindowScene)?.screen.bounds.width }
+            .first ?? 0
+
+        return max(screenWidth - (horizontalMargin * 2), 0)
+    }
+
+}
+
+private struct AddressTooltipRow: View {
+    let title: String
+    let address: String
+
+    var body: some View {
         HStack(spacing: Spacing.spacing150) {
-            Text(title)
-                .pretendardCustomFont(textStyle: .labelSmallEmphasized)
-                .foregroundStyle(Colors.gray800)
+            AddressTypeBadge(title: title)
 
             Text(address)
                 .pretendardCustomFont(textStyle: .labelSmall)
@@ -159,10 +165,31 @@ private extension NearbyPlaceAddressTooltip {
                 .foregroundStyle(Colors.gray600)
             }
             .buttonStyle(.plain)
-            .accessibilityLabel("\(title) 주소 복사")
         }
     }
 }
+
+private struct AddressTypeBadge: View {
+    let title: String
+
+    var body: some View {
+        Text(title)
+            .pretendardCustomFont(textStyle: .labelSmallEmphasized)
+            .foregroundStyle(Colors.gray800)
+            .padding(.horizontal, Spacing.spacing150)
+            .padding(.vertical, Spacing.spacing50)
+            .background(
+                RoundedRectangle(cornerRadius: BorderRadius.borderRadius150)
+                    .fill(Colors.gray00)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: BorderRadius.borderRadius150)
+                    .stroke(Colors.gray200, lineWidth: 1)
+            )
+    }
+}
+
+// MARK: - Thumbnail
 
 private struct NearbyPlaceThumbnail: View {
     private let imageURL = URL(string: "https://picsum.photos/seed/bangawo-place/160")
@@ -191,7 +218,9 @@ private struct NearbyPlaceThumbnail: View {
     }
 }
 
-/// 장소 태그 칩 UI
+// MARK: - Place Tag
+
+/// 장소 특성을 보여주는 작은 태그 칩입니다.
 private struct PlaceTagChip: View {
     let tag: PlaceTag
 

--- a/Projects/Presentation/HomeFeature/Sources/MeetingDetail/MapBottomSheet/NearbyPlaceRow.swift
+++ b/Projects/Presentation/HomeFeature/Sources/MeetingDetail/MapBottomSheet/NearbyPlaceRow.swift
@@ -1,0 +1,88 @@
+//
+//  NearbyPlaceRow.swift
+//  HomeFeature
+//
+
+import SwiftUI
+import Entity
+import DesignSystem
+
+// 역근처 장소 리스트 뷰에 들어갈 UI
+
+struct NearbyPlaceRow: View {
+    // TODO: data 서버 모델로 변경 필요
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack(alignment: .top, spacing: 0) {
+                Text("이미지")
+                VStack(alignment: .leading, spacing: 0) {
+                    Text("이름")
+                    HStack(spacing: 0) {
+                        Text("18km")
+                            .pretendardCustomFont(textStyle: .bodyMedium)
+                            .foregroundStyle(Color.gray600)
+                        Text("서울 강남구 역삼동")
+                            .pretendardCustomFont(textStyle: .bodyMedium)
+                            .foregroundStyle(Color.gray700)
+                    }
+                    HStack(spacing: 0) {
+                        PlaceTagChip(tag: .spaciousSeating)
+                    }
+                }
+            }
+        }
+    }
+}
+// 장소 태그 칩 UI
+private struct PlaceTagChip: View {
+    let tag: PlaceTag
+
+    var body: some View {
+        Text("# \(tag.rawValue)")
+            .pretendardCustomFont(textStyle: .labelXSmall)
+            .foregroundStyle(foregroundColor)
+            .padding(.horizontal, Spacing.spacing150)
+            .padding(.vertical, Spacing.spacing100)
+            .background(
+                RoundedRectangle(cornerRadius: BorderRadius.borderRadius150)
+                    .fill(backgroundColor)
+            )
+    }
+}
+
+private extension PlaceTagChip {
+    var foregroundColor: Color {
+  
+        switch tag {
+        case .reservable:
+            return Colors.green600
+        case .quiet:
+            return Colors.gray800
+        case .goodMood:
+            return Colors.gray800
+        case .parkingAvailable:
+            return Colors.blue600
+        case .spaciousSeating:
+            return Colors.gray800
+        }
+    }
+
+    var backgroundColor: Color {
+        switch tag {
+        case .reservable:
+            return Colors.green100
+        case .quiet:
+            return Colors.gray100
+        case .goodMood:
+            return Colors.gray100
+        case .parkingAvailable:
+            return Colors.blue100
+        case .spaciousSeating:
+            return Colors.gray100
+        }
+    }
+}
+
+#Preview {
+    NearbyPlaceRow()
+}

--- a/Projects/Presentation/HomeFeature/Sources/MeetingDetail/MapBottomSheet/NearbyPlaceRow.swift
+++ b/Projects/Presentation/HomeFeature/Sources/MeetingDetail/MapBottomSheet/NearbyPlaceRow.swift
@@ -3,9 +3,9 @@
 //  HomeFeature
 //
 
-import SwiftUI
-import Entity
 import DesignSystem
+import Entity
+import SwiftUI
 
 // 역근처 장소 리스트 뷰에 들어갈 UI
 
@@ -13,11 +13,11 @@ struct NearbyPlaceRow: View {
     // TODO: data 서버 모델로 변경 필요
     var body: some View {
         VStack(spacing: 0) {
-            HStack(alignment: .top, spacing: 0) {
-                Text("이미지")
-                VStack(alignment: .leading, spacing: 0) {
+            HStack(alignment: .top, spacing: Spacing.spacing300) {
+                NearbyPlaceThumbnail()
+                VStack(alignment: .leading, spacing: Spacing.spacing200) {
                     Text("이름")
-                    HStack(spacing: 0) {
+                    HStack(spacing: Spacing.spacing225) {
                         Text("18km")
                             .pretendardCustomFont(textStyle: .bodyMedium)
                             .foregroundStyle(Color.gray600)
@@ -25,15 +25,49 @@ struct NearbyPlaceRow: View {
                             .pretendardCustomFont(textStyle: .bodyMedium)
                             .foregroundStyle(Color.gray700)
                     }
-                    HStack(spacing: 0) {
+                    HStack(spacing: Spacing.spacing200) {
                         PlaceTagChip(tag: .spaciousSeating)
+                        PlaceTagChip(tag: .spaciousSeating)
+                        PlaceTagChip(tag: .spaciousSeating)
+                        PlaceTagChip(tag: .spaciousSeating)
+                        PlaceTagChip(tag: .spaciousSeating)
+                        PlaceTagChip(tag: .spaciousSeating)
+
                     }
                 }
             }
         }
     }
 }
-// 장소 태그 칩 UI
+
+private struct NearbyPlaceThumbnail: View {
+    private let imageURL = URL(string: "https://picsum.photos/seed/bangawo-place/160")
+
+    var body: some View {
+        AsyncImage(url: imageURL) { phase in
+            switch phase {
+            case .success(let image):
+                image
+                    .resizable()
+                    .scaledToFill()
+            case .empty, .failure:
+                Circle()
+                    .fill(Colors.gray100)
+                    .overlay(
+                        Image(systemName: "photo")
+                            .foregroundStyle(Colors.gray500)
+                    )
+            @unknown default:
+                Circle()
+                    .fill(Colors.gray100)
+            }
+        }
+        .frame(width: 32, height: 32)
+        .clipShape(Circle())
+    }
+}
+
+/// 장소 태그 칩 UI
 private struct PlaceTagChip: View {
     let tag: PlaceTag
 
@@ -52,7 +86,6 @@ private struct PlaceTagChip: View {
 
 private extension PlaceTagChip {
     var foregroundColor: Color {
-  
         switch tag {
         case .reservable:
             return Colors.green600

--- a/Projects/Presentation/HomeFeature/Sources/MeetingDetail/MapBottomSheet/NearbyPlaceRow.swift
+++ b/Projects/Presentation/HomeFeature/Sources/MeetingDetail/MapBottomSheet/NearbyPlaceRow.swift
@@ -6,11 +6,14 @@
 import DesignSystem
 import Entity
 import SwiftUI
+import UIKit
 
 // 역근처 장소 리스트 뷰에 들어갈 UI
 
 struct NearbyPlaceRow: View {
     // TODO: data 서버 모델로 변경 필요
+    @State private var isTooltipPresented = false
+
     var body: some View {
         VStack(spacing: 0) {
             HStack(alignment: .top, spacing: Spacing.spacing300) {
@@ -21,21 +24,89 @@ struct NearbyPlaceRow: View {
                         Text("18km")
                             .pretendardCustomFont(textStyle: .bodyMedium)
                             .foregroundStyle(Color.gray600)
-                        Text("서울 강남구 역삼동")
-                            .pretendardCustomFont(textStyle: .bodyMedium)
-                            .foregroundStyle(Color.gray700)
+                        HStack(spacing: Spacing.spacing100) {
+                            Text("서울 강남구 역삼동")
+                                .pretendardCustomFont(textStyle: .bodyMedium)
+                                .foregroundStyle(Color.gray700)
+
+                            Button {
+                                withAnimation(.easeInOut(duration: 0.2)) {
+                                    isTooltipPresented.toggle()
+                                }
+                            } label: {
+                                Image(assetName: "ic_arrow_small_down_16")
+                                    .renderingMode(.template)
+                                    .foregroundStyle(Colors.gray500)
+                                    .frame(width: 16, height: 16)
+                            }
+                            .buttonStyle(.plain)
+                            .accessibilityLabel("주소 안내 보기")
+                        }
+                        .overlay(alignment: .bottomLeading) {
+                            if isTooltipPresented {
+                                NearbyPlaceAddressTooltip()
+                                    .offset(y: 32)
+                                    .transition(.opacity.combined(with: .move(edge: .bottom)))
+                            }
+                        }
+                        .zIndex(1)
                     }
+                    .zIndex(1)
+
                     HStack(spacing: Spacing.spacing200) {
+                        PlaceTagChip(tag: .reservable)
                         PlaceTagChip(tag: .spaciousSeating)
-                        PlaceTagChip(tag: .spaciousSeating)
-                        PlaceTagChip(tag: .spaciousSeating)
-                        PlaceTagChip(tag: .spaciousSeating)
-                        PlaceTagChip(tag: .spaciousSeating)
-                        PlaceTagChip(tag: .spaciousSeating)
+                        PlaceTagChip(tag: .parkingAvailable)
 
                     }
+                    .zIndex(0)
                 }
             }
+        }
+    }
+}
+
+private struct NearbyPlaceAddressTooltip: View {
+    private let roadAddress = "서울 강남구 테헤란로 123"
+    private let lotAddress = "서울 강남구 역삼동 123-45"
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Spacing.spacing200) {
+            addressTooltipRow(title: "도로명", address: roadAddress)
+            addressTooltipRow(title: "지번", address: lotAddress)
+        }
+        .padding(.horizontal, Spacing.spacing250)
+        .padding(.vertical, Spacing.spacing200)
+        .background(
+            RoundedRectangle(cornerRadius: BorderRadius.borderRadius200)
+                .fill(Colors.gray100)
+        )
+    }
+}
+
+private extension NearbyPlaceAddressTooltip {
+    func addressTooltipRow(title: String, address: String) -> some View {
+        HStack(spacing: Spacing.spacing150) {
+            Text(title)
+                .pretendardCustomFont(textStyle: .labelSmallEmphasized)
+                .foregroundStyle(Colors.gray800)
+
+            Text(address)
+                .pretendardCustomFont(textStyle: .labelSmall)
+                .foregroundStyle(Colors.gray700)
+
+            Button {
+                UIPasteboard.general.string = address
+            } label: {
+                HStack(spacing: Spacing.spacing50) {
+                    Image(assetName: "ic_copy_16")
+                        .renderingMode(.template)
+                        .frame(width: 16, height: 16)
+                }
+                .foregroundStyle(Colors.gray600)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("\(title) 주소 복사")
         }
     }
 }

--- a/Projects/Presentation/HomeFeature/Sources/MeetingDetail/MapBottomSheet/PlaceAddressRow.swift
+++ b/Projects/Presentation/HomeFeature/Sources/MeetingDetail/MapBottomSheet/PlaceAddressRow.swift
@@ -1,0 +1,66 @@
+//
+//  PlaceAddressRow.swift
+//  HomeFeature
+//
+
+import SwiftUI
+import UIKit
+import DesignSystem
+
+struct PlaceAddressRow: View {
+    let title: String
+    let address: String
+
+    var body: some View {
+        HStack(spacing: Spacing.spacing150) {
+            AddressTypeBadge(title: title)
+
+            Text(address)
+                .pretendardCustomFont(textStyle: .bodySmall)
+                .foregroundStyle(Colors.gray700)
+                .lineLimit(1)
+                .truncationMode(.tail)
+
+            Button {
+                UIPasteboard.general.string = address
+            } label: {
+                HStack(spacing: Spacing.spacing50) {
+                    Image(assetName: "ic_copy_16")
+                        .renderingMode(.template)
+                        .frame(width: 16, height: 16)
+                }
+                .foregroundStyle(Colors.gray600)
+            }
+            .buttonStyle(.plain)
+        }
+    }
+}
+
+private struct AddressTypeBadge: View {
+    let title: String
+
+    var body: some View {
+        Text(title)
+            .pretendardCustomFont(textStyle: .labelXSmall)
+            .foregroundStyle(Colors.gray800)
+            .padding(.horizontal, Spacing.spacing150)
+            .padding(.vertical, Spacing.spacing50)
+            .background(
+                RoundedRectangle(cornerRadius: BorderRadius.borderRadius250)
+                    .fill(Colors.gray00)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: BorderRadius.borderRadius250)
+                    .stroke(Colors.gray300, lineWidth: 1)
+            )
+    }
+}
+
+#Preview {
+    VStack(alignment: .leading, spacing: Spacing.spacing200) {
+        PlaceAddressRow(title: "도로명", address: "서울 강남구 테헤란로 123")
+        PlaceAddressRow(title: "지번", address: "서울 강남구 역삼동 123-45")
+    }
+    .padding(Spacing.spacing400)
+    .background(Colors.gray00)
+}

--- a/Projects/Presentation/HomeFeature/Sources/MeetingDetail/MapBottomSheet/SelectedPlace/SelectedPlaceDetailSheet.swift
+++ b/Projects/Presentation/HomeFeature/Sources/MeetingDetail/MapBottomSheet/SelectedPlace/SelectedPlaceDetailSheet.swift
@@ -1,0 +1,17 @@
+//
+//  Selected.swift
+//  HomeFeature
+//
+
+import SwiftUI
+import DesignSystem
+
+/// 특정 장소 핀 선택시 보여줄 디테일 시트
+struct SelectedPlaceDetailSheet: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: Spacing.spacing300) {
+            // 장소명, 주소, 태그, 액션 버튼 등
+        }
+        .padding(.horizontal, Spacing.spacing400)
+    }
+}

--- a/Projects/Presentation/HomeFeature/Sources/MeetingDetail/MapBottomSheet/SelectedPlace/SelectedPlaceDetailSheet.swift
+++ b/Projects/Presentation/HomeFeature/Sources/MeetingDetail/MapBottomSheet/SelectedPlace/SelectedPlaceDetailSheet.swift
@@ -9,9 +9,118 @@ import DesignSystem
 /// 특정 장소 핀 선택시 보여줄 디테일 시트
 struct SelectedPlaceDetailSheet: View {
     var body: some View {
-        VStack(alignment: .leading, spacing: Spacing.spacing300) {
-            // 장소명, 주소, 태그, 액션 버튼 등
+        VStack(alignment: .leading, spacing: 0) {
+            SelectedPlaceDetailHeaderView()
+                .padding(.bottom, Spacing.spacing350)
+            SelectedPlaceBusinessHoursView()
+                .padding(.bottom, Spacing.spacing350)
+            SelectedPlaceAddressView()
+                .padding(.bottom, Spacing.spacing500)
+            SelectedPlaceNaverMapButton()
         }
         .padding(.horizontal, Spacing.spacing400)
     }
+}
+
+private struct SelectedPlaceDetailHeaderView: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack(spacing: 0) {
+                Text("서촌김씨")
+                    .pretendardCustomFont(textStyle: .titleLarge)
+                    .foregroundStyle(Color.gray800)
+
+                Spacer()
+
+                Image.Asset.icClose24
+                    .resizable()
+                    .renderingMode(.template)
+                    .frame(width: 24, height: 24)
+                    .foregroundStyle(Colors.gray500)
+            }
+            .padding(.bottom, 4)
+
+            HStack(spacing: Spacing.spacing150) {
+                Text("18km")
+                    .pretendardCustomFont(textStyle: .bodyMedium)
+                    .foregroundStyle(Colors.gray600)
+
+                SelectedPlaceMetadataDivider()
+
+                Text("디저트")
+                    .pretendardCustomFont(textStyle: .bodyMedium)
+                    .foregroundStyle(Colors.gray700)
+            }
+            .padding(.top, Spacing.spacing100)
+        }
+    }
+}
+
+private struct SelectedPlaceBusinessHoursView: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: Spacing.spacing100) {
+            Text("영업 시간")
+                .pretendardCustomFont(textStyle: .bodySmall)
+                .foregroundStyle(Color.gray900)
+            Group {
+                Text("월 휴무")
+                    
+                Text("평일 08:00 - 22:00 / 주말 11:11 - 22:22")
+            }
+            .pretendardCustomFont(textStyle: .bodySmall)
+            .foregroundStyle(Color.gray700)
+           
+        }
+    }
+}
+
+private struct SelectedPlaceAddressView: View {
+    private let roadAddress = "서울 강남구 테헤란로 123"
+    private let lotAddress = "서울 강남구 역삼동 123-45"
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Spacing.spacing200) {
+            Text("주소")
+                .pretendardCustomFont(textStyle: .bodySmall)
+                .foregroundStyle(Color.gray900)
+
+            VStack(alignment: .leading, spacing: Spacing.spacing200) {
+                PlaceAddressRow(title: "도로명", address: roadAddress)
+                PlaceAddressRow(title: "지번", address: lotAddress)
+            }
+        }
+    }
+}
+
+private struct SelectedPlaceNaverMapButton: View {
+    var body: some View {
+        Button {
+        } label: {
+            Text("네이버 지도로 보기")
+                .pretendardCustomFont(textStyle: .labelLarge)
+                .foregroundStyle(Colors.gray00)
+                .frame(maxWidth: .infinity)
+                .frame(height: 56)
+                .background(
+                    RoundedRectangle(cornerRadius: BorderRadius.borderRadius300)
+                        .fill(Colors.gray800)
+                )
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+private struct SelectedPlaceMetadataDivider: View {
+    var body: some View {
+        Circle()
+            .fill(Colors.gray300)
+            .frame(width: 2, height: 2)
+    }
+}
+
+#Preview {
+    SelectedPlaceDetailSheet()
+        .padding(.vertical, Spacing.spacing300)
+        .frame(maxWidth: .infinity, alignment: .topLeading)
+        .background(Colors.gray00)
 }

--- a/Projects/Presentation/HomeFeature/Sources/MeetingDetail/MeetingDetailFeature.swift
+++ b/Projects/Presentation/HomeFeature/Sources/MeetingDetail/MeetingDetailFeature.swift
@@ -11,17 +11,29 @@ public struct MeetingDetailFeature {
     @ObservableState
     public struct State: Equatable {
         public let meeting: Meeting
+        public var nearbyPlaceList: NearbyPlaceListSheetFeature.State = .init()
 
         public init(meeting: Meeting) {
             self.meeting = meeting
         }
     }
 
-    public enum Action {}
+    public enum Action {
+        case nearbyPlaceList(NearbyPlaceListSheetFeature.Action)
+    }
 
     public init() {}
 
     public var body: some ReducerOf<Self> {
-        Reduce { _, _ in .none }
+        Scope(state: \.nearbyPlaceList, action: \.nearbyPlaceList) {
+            NearbyPlaceListSheetFeature()
+        }
+
+        Reduce { _, action in
+            switch action {
+            case .nearbyPlaceList:
+                return .none
+            }
+        }
     }
 }

--- a/Projects/Presentation/HomeFeature/Sources/MeetingDetail/MeetingDetailFeature.swift
+++ b/Projects/Presentation/HomeFeature/Sources/MeetingDetail/MeetingDetailFeature.swift
@@ -29,7 +29,7 @@ public struct MeetingDetailFeature {
             NearbyPlaceListSheetFeature()
         }
 
-        Reduce { _, action in
+        Reduce { state, action in
             switch action {
             case .nearbyPlaceList:
                 return .none

--- a/Projects/Presentation/HomeFeature/Sources/MeetingDetail/MeetingDetailView.swift
+++ b/Projects/Presentation/HomeFeature/Sources/MeetingDetail/MeetingDetailView.swift
@@ -29,12 +29,9 @@ public struct MeetingDetailView: View {
             .background(.gray200)
             // TODO: 임시로 여기다가 붙여놓음 나중에 상세 지도 뷰 위에 오버레이 시켜주기
             MapBottomSheet {
-                VStack(alignment: .leading, spacing: Spacing.spacing200) {
-                    NearbyPlaceRow()
-                    NearbyPlaceRow()
-                    NearbyPlaceRow()
-                }
-                .padding(.horizontal, Spacing.spacing400)
+                NearbyPlaceListSheet(
+                    store: store.scope(state: \.nearbyPlaceList, action: \.nearbyPlaceList)
+                )
             }
         }
         .navigationTitle(store.meeting.title)

--- a/Projects/Presentation/HomeFeature/Sources/MeetingDetail/MeetingDetailView.swift
+++ b/Projects/Presentation/HomeFeature/Sources/MeetingDetail/MeetingDetailView.swift
@@ -27,19 +27,15 @@ public struct MeetingDetailView: View {
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .background(.gray200)
-
+            // TODO: 임시로 여기다가 붙여놓음 나중에 상세 지도 뷰 위에 오버레이 시켜주기
             MapBottomSheet {
-                VStack(spacing: Spacing.spacing200) {
-                    Text("hello")
-                    Text("hello")
-                    Text("hello")
-                    Text("hello")
-                    Text("hello")
-                    Text("hello")
+                VStack(alignment: .leading, spacing: Spacing.spacing200) {
+                    NearbyPlaceRow()
+                    NearbyPlaceRow()
+                    NearbyPlaceRow()
                 }
-                .padding(.horizontal, Spacing.spacing300)
+                .padding(.horizontal, Spacing.spacing400)
             }
-            .padding(.horizontal, Spacing.spacing300)
         }
         .navigationTitle(store.meeting.title)
         .navigationBarTitleDisplayMode(.inline)

--- a/Projects/Presentation/HomeFeature/Sources/MeetingDetail/MeetingDetailView.swift
+++ b/Projects/Presentation/HomeFeature/Sources/MeetingDetail/MeetingDetailView.swift
@@ -15,17 +15,32 @@ public struct MeetingDetailView: View {
     }
 
     public var body: some View {
-        VStack(spacing: Spacing.spacing300) {
-            Text(store.meeting.title)
-                .pretendardCustomFont(textStyle: .headingSmall)
-                .foregroundStyle(.gray900)
+        ZStack(alignment: .bottom) {
+            VStack(spacing: Spacing.spacing300) {
+                Text(store.meeting.title)
+                    .pretendardCustomFont(textStyle: .headingSmall)
+                    .foregroundStyle(.gray900)
 
-            Text("모임 상세 화면 (임시)")
-                .pretendardCustomFont(textStyle: .bodySmall)
-                .foregroundStyle(.gray600)
+                Text("모임 상세 화면 (임시)")
+                    .pretendardCustomFont(textStyle: .bodySmall)
+                    .foregroundStyle(.gray600)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(.gray200)
+
+            MapBottomSheet {
+                VStack(spacing: Spacing.spacing200) {
+                    Text("hello")
+                    Text("hello")
+                    Text("hello")
+                    Text("hello")
+                    Text("hello")
+                    Text("hello")
+                }
+                .padding(.horizontal, Spacing.spacing300)
+            }
+            .padding(.horizontal, Spacing.spacing300)
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(.gray200)
         .navigationTitle(store.meeting.title)
         .navigationBarTitleDisplayMode(.inline)
     }


### PR DESCRIPTION
📌 PR Summary

지도 상세 화면에서 사용할 커스텀 바텀시트와 장소 정보 UI를 추가했습니다.
지도 위에서 근처 장소를 탐색하고, 특정 장소를 선택했을 때 상세 정보를 확인할 수 있는 기본 화면 구조를 구성했습니다.

✨ 주요 변경사항

• MapBottomSheet 커스텀 바텀시트 추가
   - 접힘 / 중간 / 확장 3단계 상태 지원
   - 드래그 및 핸들 탭을 통한 높이 전환 지원
   - 장소 선택 시 사용할 고정 높이 모드 추가
   
• 근처 장소 리스트 시트 추가
   -  카테고리 필터 UI 추가
   - 주차 가능 / 예약 가능 필터 UI 추가
   - 장소 Row UI 추가

• 장소 주소 툴팁 추가
   - 도로명 / 지번 주소 표시
   - 주소 복사 기능 포함

• 선택 장소 상세 시트 추가
   - 장소 기본 정보
   - 영업시간
   - 주소 정보
   - 네이버 지도로 보기 버튼

• 주소 Row를 공통 컴포넌트로 분리해 리스트 툴팁과 상세 시트에서 재사용

🧩 구조

• 바텀시트 컨테이너와 내부 콘텐츠를 분리해 재사용 가능하게 구성했습니다.
• 바텀시트 모드를 분리해 일반 리스트 시트와 선택 장소 상세 시트의 동작을 다르게 처리할 수 있도록 했습니다.
• 주소 표시 UI를 공통화해 중복 구현을 줄였습니다.

✅ 검증

• Xcode 진단 이슈 없음
• BuildProject 성공

참고
- API  연동 전