### PR TITLE
[CHORE] design-tokens 자동 반영

### DIFF
--- a/Projects/Shared/DesignSystem/Sources/Tokens/Generated/Spacing+Generated.swift
+++ b/Projects/Shared/DesignSystem/Sources/Tokens/Generated/Spacing+Generated.swift
@@ -7,6 +7,7 @@
 import CoreGraphics
 
 public enum Spacing {
+    public static let spacing25: CGFloat = 1
     public static let spacing50: CGFloat = 2
     public static let spacing100: CGFloat = 4
     public static let spacing150: CGFloat = 6


### PR DESCRIPTION
## 자동 생성된 디자인 토큰 반영

**Source**: [`zizizoi0709-p/design-tokens@3d8c797e23ba74ea863926f4727226f8d294aff6`](https://github.com/zizizoi0709-p/design-tokens/commit/3d8c797e23ba74ea863926f4727226f8d294aff6)
**Trigger**: `push` on `main`
**Workflow run**: [#11](https://github.com/zizizoi0709-p/design-tokens/actions/runs/28006849359)
**Branch**: `chore/design-tokens-sync-20260623-062716` → `develop`

### 변경된 파일 (베이스: `Projects/Shared/DesignSystem/`)
- `Resources/Colors.xcassets/` (Asset Catalog)
- `Sources/Color/Generated/Colors+Generated.swift`
- `Sources/CustomFont/Generated/Typography+Generated.swift`
- `Sources/Tokens/Generated/Spacing+Generated.swift`
- `Sources/Tokens/Generated/Sizing+Generated.swift`
- `Sources/Tokens/Generated/BorderRadius+Generated.swift`
- `Sources/Tokens/Generated/BorderWidth+Generated.swift`
- `Sources/Tokens/Generated/Opacity+Generated.swift`
- `Sources/Tokens/Generated/BoxShadow+Generated.swift`

### 머지 후 작업
신규 파일이 Xcode 프로젝트에 반영되도록 로컬에서 아래를 실행한다.

```bash
./tuisttool generate && tuist graph
```

> 자동 생성된 PR입니다. 토큰 변경 시마다 새 브랜치/새 PR이 생성되므로
> 머지하지 않은 채로 누적될 수 있습니다. 머지 후엔 브랜치가 자동 삭제됩니다.