### PR TITLE
[FEAT] 모임 상세 출발지 추가 및 수정 플로우 연결

### DIFF
--- a/Projects/Presentation/HomeFeature/Project.swift
+++ b/Projects/Presentation/HomeFeature/Project.swift
@@ -16,6 +16,7 @@ let project = Project.makeModule(
     .Domain(implements: .UseCase),
     .Domain(implements: .Entity),
     .Core(implements: .CoreDependencies),
+    .Presentation(implements: .StationSearchFeature),
     .SPM.composableArchitecture,
   ],
   sources: ["Sources/**"]

--- a/Projects/Presentation/HomeFeature/Sources/GroupDetail/GroupDetailFeature.swift
+++ b/Projects/Presentation/HomeFeature/Sources/GroupDetail/GroupDetailFeature.swift
@@ -41,6 +41,7 @@ public struct GroupDetailFeature {
         public enum Delegate: Equatable {
             case meetingDateSelectionRequested(meetingId: Int)
             case departurePlaceStationSearchRequested
+            case departurePlaceEditStationSearchRequested(id: Int)
         }
     }
 
@@ -71,6 +72,9 @@ public struct GroupDetailFeature {
 
             case .home(.delegate(.departurePlaceStationSearchRequested)):
                 return .send(.delegate(.departurePlaceStationSearchRequested))
+
+            case let .home(.delegate(.departurePlaceEditStationSearchRequested(id))):
+                return .send(.delegate(.departurePlaceEditStationSearchRequested(id: id)))
 
             case .home, .myPlace:
                 return .none

--- a/Projects/Presentation/HomeFeature/Sources/GroupDetail/GroupDetailFeature.swift
+++ b/Projects/Presentation/HomeFeature/Sources/GroupDetail/GroupDetailFeature.swift
@@ -40,6 +40,7 @@ public struct GroupDetailFeature {
 
         public enum Delegate: Equatable {
             case meetingDateSelectionRequested(meetingId: Int)
+            case departurePlaceStationSearchRequested
         }
     }
 
@@ -67,6 +68,9 @@ public struct GroupDetailFeature {
             case let .home(.delegate(.meetingDateSelectionRequested(meetingId))):
                 Log.debug("약속정하기 클릭")
                 return .send(.delegate(.meetingDateSelectionRequested(meetingId: meetingId)))
+
+            case .home(.delegate(.departurePlaceStationSearchRequested)):
+                return .send(.delegate(.departurePlaceStationSearchRequested))
 
             case .home, .myPlace:
                 return .none

--- a/Projects/Presentation/HomeFeature/Sources/GroupDetail/Tabs/HomeTab/HomeTab.swift
+++ b/Projects/Presentation/HomeFeature/Sources/GroupDetail/Tabs/HomeTab/HomeTab.swift
@@ -26,6 +26,21 @@ struct HomeTab: View {
             }
         }
         .task { store.send(.onAppear) }
+        .bottomSheet(
+            isPresented: Binding(
+                get: { store.isMyDeparturePlaceEditSheetPresented },
+                set: { isPresented in
+                    guard !isPresented else { return }
+                    store.send(.myDeparturePlaceEditSheetDismissed)
+                }
+            ),
+            header: .init(
+                title: "출발지 수정",
+                onClose: { store.send(.myDeparturePlaceEditSheetDismissed) }
+            )
+        ) {
+            MyDeparturePlaceEditSheetContent(store: store)
+        }
         .fullScreenCover(
             item: $store.scope(state: \.destination?.dateVote, action: \.destination.dateVote)
         ) { dateVoteStore in

--- a/Projects/Presentation/HomeFeature/Sources/GroupDetail/Tabs/HomeTab/HomeTab.swift
+++ b/Projects/Presentation/HomeFeature/Sources/GroupDetail/Tabs/HomeTab/HomeTab.swift
@@ -41,6 +41,22 @@ struct HomeTab: View {
         ) {
             MyDeparturePlaceEditSheetContent(store: store)
         }
+        .bottomSheet(
+            isPresented: Binding(
+                get: { store.isMyAttendanceStatusSheetPresented },
+                set: { isPresented in
+                    guard !isPresented else { return }
+                    store.send(.myAttendanceStatusSheetDismissed)
+                }
+            )
+        ) {
+            MyAttendanceStatusEditSheetContent(
+                selectedStatus: store.groupDetail?.members.first(where: { $0.isMe })?.attendanceStatus,
+                onSelect: { status in
+                    store.send(.myAttendanceStatusSelected(status))
+                }
+            )
+        }
         .fullScreenCover(
             item: $store.scope(state: \.destination?.dateVote, action: \.destination.dateVote)
         ) { dateVoteStore in

--- a/Projects/Presentation/HomeFeature/Sources/GroupDetail/Tabs/HomeTab/HomeTabFeature.swift
+++ b/Projects/Presentation/HomeFeature/Sources/GroupDetail/Tabs/HomeTab/HomeTabFeature.swift
@@ -7,6 +7,7 @@ import ComposableArchitecture
 
 import CoreDependencies
 import Entity
+import Utill
 
 @Reducer
 public struct HomeTabFeature {
@@ -34,6 +35,7 @@ public struct HomeTabFeature {
         public var placeVote: PlaceVote?
         /// 장소 확정 후(`completed`/`confirmed`)일 때 `fetchConfirmedPlaceResult`로 로드하는 확정 장소 결과.
         public var confirmedPlaceResult: ConfirmedPlaceResult?
+        public var isMyDeparturePlaceEditSheetPresented = false // 출발지 수정 바텀시트 여부
 
         public init(group: Group) {
             self.group = group
@@ -113,6 +115,8 @@ public struct HomeTabFeature {
         case placeVoteResponse(Result<PlaceVote, Error>)
         case confirmedPlaceResultResponse(Result<ConfirmedPlaceResult, Error>)
         case myAttendanceBadgeTapped
+        case myMemberCardTapped // 나 카드 영역 터치 시(참석여부 버튼 제외)
+        case myDeparturePlaceEditSheetDismissed // 출발지 수정 닫혔을 때 액션
         case decidePlaceTapped
         case inviteFriendTapped
         case dateVoteTapped
@@ -175,6 +179,18 @@ public struct HomeTabFeature {
 
             // TODO: 나 영역 참여 상태 변경 시트/플로우 연동
             case .myAttendanceBadgeTapped:
+                return .none
+
+            case .myMemberCardTapped:
+                Log.debug("내 멤버 카드 클릭")
+                state.isMyDeparturePlaceEditSheetPresented = true
+                return .none
+
+            case .myDeparturePlaceEditSheetDismissed:
+                guard state.isMyDeparturePlaceEditSheetPresented else { return .none }
+
+                Log.debug("바텀시트 닫힘")
+                state.isMyDeparturePlaceEditSheetPresented = false
                 return .none
 
             case .decidePlaceTapped:

--- a/Projects/Presentation/HomeFeature/Sources/GroupDetail/Tabs/HomeTab/HomeTabFeature.swift
+++ b/Projects/Presentation/HomeFeature/Sources/GroupDetail/Tabs/HomeTab/HomeTabFeature.swift
@@ -23,6 +23,7 @@ public struct HomeTabFeature {
     @Dependency(\.groupClient) private var groupClient
     @Dependency(\.voteClient) private var voteClient
     @Dependency(\.placeRecommendationClient) private var placeRecommendationClient
+    @Dependency(\.departurePlaceClient) private var departurePlaceClient
 
     @ObservableState
     public struct State: Equatable {
@@ -134,6 +135,8 @@ public struct HomeTabFeature {
         case placeVoteSubmitResponse(Result<Void, Error>)
         case placeDetailTapped
         case addDeparturePlaceTapped // 바텀시트에서 출발지 추가하기 버튼 클릭 시
+        case departurePlaceCardTapped(id: Int) // 출발지 수정 바텀시트에서 출발지 요소 클릭 시(id 전달하기)
+        case setDefaultDeparturePlaceResponse(Result<DeparturePlace, Error>)
         case editDeparturePlaceTapped(id: Int)
         case delegate(Delegate)
         case destination(PresentationAction<Destination.Action>)
@@ -326,6 +329,25 @@ public struct HomeTabFeature {
                 state.isMyDeparturePlaceEditSheetPresented = false
                 return .send(.delegate(.departurePlaceStationSearchRequested))
 
+            case let .departurePlaceCardTapped(id):
+                Log.debug("출발지 카드 클릭: \(id)")
+                let client = departurePlaceClient
+                return .run { send in
+                    await send(.setDefaultDeparturePlaceResponse(
+                        Result { try await client.setDefaultDeparturePlace(id) }
+                    ))
+                }
+
+            case let .setDefaultDeparturePlaceResponse(.success(departurePlace)):
+                Log.debug("기본 출발지 설정 성공: \(departurePlace.id)")
+                state.updateDefaultDeparturePlace(departurePlace)
+                state.isMyDeparturePlaceEditSheetPresented = false
+                return .none
+
+            case let .setDefaultDeparturePlaceResponse(.failure(error)):
+                Log.debug("기본 출발지 설정 실패: \(error)")
+                return .none
+
             case let .editDeparturePlaceTapped(id):
                 Log.debug("출발지 수정하기 버튼 클릭: \(id)")
                 state.isMyDeparturePlaceEditSheetPresented = false
@@ -387,6 +409,61 @@ public struct HomeTabFeature {
 }
 
 private extension HomeTabFeature.State {
+    mutating func updateDefaultDeparturePlace(_ selectedDeparturePlace: DeparturePlace) {
+        guard let detail = groupDetail else { return }
+
+        let members = detail.members.map { member in
+            guard member.isMe else { return member }
+
+            let departurePlaces = member.departurePlaces.map { departurePlace in
+                if departurePlace.id == selectedDeparturePlace.id {
+                    return DeparturePlace(
+                        id: selectedDeparturePlace.id,
+                        label: selectedDeparturePlace.label,
+                        address: selectedDeparturePlace.address,
+                        roadAddress: selectedDeparturePlace.roadAddress,
+                        placeName: selectedDeparturePlace.placeName,
+                        latitude: selectedDeparturePlace.latitude,
+                        longitude: selectedDeparturePlace.longitude,
+                        isDefault: true
+                    )
+                }
+
+                return DeparturePlace(
+                    id: departurePlace.id,
+                    label: departurePlace.label,
+                    address: departurePlace.address,
+                    roadAddress: departurePlace.roadAddress,
+                    placeName: departurePlace.placeName,
+                    latitude: departurePlace.latitude,
+                    longitude: departurePlace.longitude,
+                    isDefault: false
+                )
+            }
+
+            return GroupDetailMember(
+                id: member.id,
+                nickname: member.nickname,
+                profileImageUrl: member.profileImageUrl,
+                isHost: member.isHost,
+                isMe: member.isMe,
+                attendanceStatus: member.attendanceStatus,
+                departurePlaces: departurePlaces
+            )
+        }
+
+        groupDetail = GroupDetail(
+            id: detail.id,
+            name: detail.name,
+            themeTagCode: detail.themeTagCode,
+            themeTagDisplay: detail.themeTagDisplay,
+            locationStatus: detail.locationStatus,
+            dateVoteStatus: detail.dateVoteStatus,
+            confirmedDate: detail.confirmedDate,
+            members: members
+        )
+    }
+
     mutating func updateMyAttendanceStatus(_ status: AttendanceStatus) {
         guard let detail = groupDetail else { return }
 

--- a/Projects/Presentation/HomeFeature/Sources/GroupDetail/Tabs/HomeTab/HomeTabFeature.swift
+++ b/Projects/Presentation/HomeFeature/Sources/GroupDetail/Tabs/HomeTab/HomeTabFeature.swift
@@ -187,6 +187,7 @@ public struct HomeTabFeature {
                 return .none
 
             case .myDeparturePlaceEditSheetDismissed:
+                // 바텀시트 닫힐 때 이벤트 중복 발생 방지
                 guard state.isMyDeparturePlaceEditSheetPresented else { return .none }
 
                 Log.debug("바텀시트 닫힘")

--- a/Projects/Presentation/HomeFeature/Sources/GroupDetail/Tabs/HomeTab/HomeTabFeature.swift
+++ b/Projects/Presentation/HomeFeature/Sources/GroupDetail/Tabs/HomeTab/HomeTabFeature.swift
@@ -36,6 +36,7 @@ public struct HomeTabFeature {
         /// 장소 확정 후(`completed`/`confirmed`)일 때 `fetchConfirmedPlaceResult`로 로드하는 확정 장소 결과.
         public var confirmedPlaceResult: ConfirmedPlaceResult?
         public var isMyDeparturePlaceEditSheetPresented = false // 출발지 수정 바텀시트 여부
+        public var isMyAttendanceStatusSheetPresented = false // 참여 상태 변경 바텀시트 여부
 
         public init(group: Group) {
             self.group = group
@@ -115,6 +116,8 @@ public struct HomeTabFeature {
         case placeVoteResponse(Result<PlaceVote, Error>)
         case confirmedPlaceResultResponse(Result<ConfirmedPlaceResult, Error>)
         case myAttendanceBadgeTapped
+        case myAttendanceStatusSheetDismissed
+        case myAttendanceStatusSelected(AttendanceStatus)
         case myMemberCardTapped // 나 카드 영역 터치 시(참석여부 버튼 제외)
         case myDeparturePlaceEditSheetDismissed // 출발지 수정 닫혔을 때 액션
         case decidePlaceTapped
@@ -179,6 +182,20 @@ public struct HomeTabFeature {
 
             // TODO: 나 영역 참여 상태 변경 시트/플로우 연동
             case .myAttendanceBadgeTapped:
+                state.isMyAttendanceStatusSheetPresented = true
+                return .none
+
+            case .myAttendanceStatusSheetDismissed:
+                guard state.isMyAttendanceStatusSheetPresented else { return .none }
+
+                Log.debug("참여 상태 변경 바텀시트 닫힘")
+                state.isMyAttendanceStatusSheetPresented = false
+                return .none
+
+            case let .myAttendanceStatusSelected(status):
+                Log.debug("참여 상태 선택: \(status.displayLabel)")
+                state.updateMyAttendanceStatus(status)
+                state.isMyAttendanceStatusSheetPresented = false
                 return .none
 
             case .myMemberCardTapped:
@@ -335,6 +352,37 @@ public struct HomeTabFeature {
                 Result { try await client.fetchConfirmedPlaceResult(meetingId: meetingId) }
             ))
         }
+    }
+}
+
+private extension HomeTabFeature.State {
+    mutating func updateMyAttendanceStatus(_ status: AttendanceStatus) {
+        guard let detail = groupDetail else { return }
+
+        let members = detail.members.map { member in
+            guard member.isMe else { return member }
+
+            return GroupDetailMember(
+                id: member.id,
+                nickname: member.nickname,
+                profileImageUrl: member.profileImageUrl,
+                isHost: member.isHost,
+                isMe: member.isMe,
+                attendanceStatus: status,
+                departurePlaces: member.departurePlaces
+            )
+        }
+
+        groupDetail = GroupDetail(
+            id: detail.id,
+            name: detail.name,
+            themeTagCode: detail.themeTagCode,
+            themeTagDisplay: detail.themeTagDisplay,
+            locationStatus: detail.locationStatus,
+            dateVoteStatus: detail.dateVoteStatus,
+            confirmedDate: detail.confirmedDate,
+            members: members
+        )
     }
 }
 

--- a/Projects/Presentation/HomeFeature/Sources/GroupDetail/Tabs/HomeTab/HomeTabFeature.swift
+++ b/Projects/Presentation/HomeFeature/Sources/GroupDetail/Tabs/HomeTab/HomeTabFeature.swift
@@ -118,6 +118,7 @@ public struct HomeTabFeature {
         case myAttendanceBadgeTapped
         case myAttendanceStatusSheetDismissed
         case myAttendanceStatusSelected(AttendanceStatus)
+        case myAttendanceStatusUpdateResponse(Result<AttendanceStatus, Error>)
         case myMemberCardTapped // 나 카드 영역 터치 시(참석여부 버튼 제외)
         case myDeparturePlaceEditSheetDismissed // 출발지 수정 닫혔을 때 액션
         case decidePlaceTapped
@@ -132,6 +133,7 @@ public struct HomeTabFeature {
         case placeVoteSubmitTapped(placeIds: [Int])
         case placeVoteSubmitResponse(Result<Void, Error>)
         case placeDetailTapped
+        case addDeparturePlaceTapped // 바텀시트에서 출발지 추가하기 버튼 클릭 시
         case delegate(Delegate)
         case destination(PresentationAction<Destination.Action>)
     }
@@ -139,6 +141,7 @@ public struct HomeTabFeature {
     public enum Delegate: Equatable {
         case selectMyPlaceTab
         case meetingDateSelectionRequested(meetingId: Int)
+        case departurePlaceStationSearchRequested
     }
 
     public init() {}
@@ -193,9 +196,25 @@ public struct HomeTabFeature {
                 return .none
 
             case let .myAttendanceStatusSelected(status):
+                let groupId = state.group.id
+                let client = groupClient
                 Log.debug("참여 상태 선택: \(status.displayLabel)")
-                state.updateMyAttendanceStatus(status)
                 state.isMyAttendanceStatusSheetPresented = false
+                return .run { send in
+                    await send(.myAttendanceStatusUpdateResponse(
+                        Result {
+                            try await client.updateAttendance(groupId, status)
+                            return status
+                        }
+                    ))
+                }
+
+            case let .myAttendanceStatusUpdateResponse(.success(status)):
+                state.updateMyAttendanceStatus(status)
+                return .none
+
+            case let .myAttendanceStatusUpdateResponse(.failure(error)):
+                Log.debug("참석 여부 변경 실패: \(error)")
                 return .none
 
             case .myMemberCardTapped:
@@ -299,6 +318,11 @@ public struct HomeTabFeature {
 
             case .placeDetailTapped:
                 return .none
+
+            case .addDeparturePlaceTapped:
+                Log.debug("출발지 추가하기 버튼 클릭")
+                state.isMyDeparturePlaceEditSheetPresented = false
+                return .send(.delegate(.departurePlaceStationSearchRequested))
 
             case .delegate, .destination:
                 return .none

--- a/Projects/Presentation/HomeFeature/Sources/GroupDetail/Tabs/HomeTab/HomeTabFeature.swift
+++ b/Projects/Presentation/HomeFeature/Sources/GroupDetail/Tabs/HomeTab/HomeTabFeature.swift
@@ -134,6 +134,7 @@ public struct HomeTabFeature {
         case placeVoteSubmitResponse(Result<Void, Error>)
         case placeDetailTapped
         case addDeparturePlaceTapped // 바텀시트에서 출발지 추가하기 버튼 클릭 시
+        case editDeparturePlaceTapped(id: Int)
         case delegate(Delegate)
         case destination(PresentationAction<Destination.Action>)
     }
@@ -142,6 +143,7 @@ public struct HomeTabFeature {
         case selectMyPlaceTab
         case meetingDateSelectionRequested(meetingId: Int)
         case departurePlaceStationSearchRequested
+        case departurePlaceEditStationSearchRequested(id: Int)
     }
 
     public init() {}
@@ -323,6 +325,11 @@ public struct HomeTabFeature {
                 Log.debug("출발지 추가하기 버튼 클릭")
                 state.isMyDeparturePlaceEditSheetPresented = false
                 return .send(.delegate(.departurePlaceStationSearchRequested))
+
+            case let .editDeparturePlaceTapped(id):
+                Log.debug("출발지 수정하기 버튼 클릭: \(id)")
+                state.isMyDeparturePlaceEditSheetPresented = false
+                return .send(.delegate(.departurePlaceEditStationSearchRequested(id: id)))
 
             case .delegate, .destination:
                 return .none

--- a/Projects/Presentation/HomeFeature/Sources/GroupDetail/Tabs/HomeTab/MemberList.swift
+++ b/Projects/Presentation/HomeFeature/Sources/GroupDetail/Tabs/HomeTab/MemberList.swift
@@ -115,19 +115,9 @@ private struct MemberRow: View {
 
     @ViewBuilder
     private var cardContent: some View {
-        if isMe {
-            Button(action: onCardTap) {
-                memberInfo
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(.vertical, Spacing.spacing300)
-                    .contentShape(Rectangle())
-            }
-            .buttonStyle(.plain)
-        } else {
-            memberInfo
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.vertical, Spacing.spacing300)
-        }
+        memberInfo
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.vertical, Spacing.spacing300)
     }
 
     private var memberInfo: some View {
@@ -144,11 +134,35 @@ private struct MemberRow: View {
                     }
                 }
 
-                BangawoText(departureLabel, textStyle: .bodyMedium)
-                    .foregroundStyle(Colors.gray700)
+                departureContent
             }
             .frame(maxWidth: .infinity, alignment: .leading)
         }
+    }
+
+    @ViewBuilder
+    private var departureContent: some View {
+        if isMe {
+            Button(action: onCardTap) {
+                HStack(spacing: Spacing.spacing100) {
+                    departureText
+
+                    Image.Asset.icArrowSmallRight24
+                        .resizable()
+                        .frame(width: Sizing.sizing200, height: Sizing.sizing200)
+                        .foregroundStyle(Colors.gray700)
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+        } else {
+            departureText
+        }
+    }
+
+    private var departureText: some View {
+        BangawoText(departureLabel, textStyle: .bodyMedium)
+            .foregroundStyle(Colors.gray700)
     }
 
     /// 기본 출발지(없으면 첫 출발지)의 장소명. 출발지가 없으면 안내 문구를 노출한다.

--- a/Projects/Presentation/HomeFeature/Sources/GroupDetail/Tabs/HomeTab/MemberList.swift
+++ b/Projects/Presentation/HomeFeature/Sources/GroupDetail/Tabs/HomeTab/MemberList.swift
@@ -27,9 +27,15 @@ struct MemberList: View {
             } else {
                 VStack(spacing: Spacing.spacing250) {
                     if let me = members.first(where: { $0.isMe }) {
-                        MeArea(member: me) {
-                            store.send(.myAttendanceBadgeTapped)
-                        }
+                        MeArea(
+                            member: me,
+                            onCardTap: {
+                                store.send(.myMemberCardTapped)
+                            },
+                            onAttendanceTap: {
+                                store.send(.myAttendanceBadgeTapped)
+                            }
+                        )
                     }
 
                     let others = members.filter { !$0.isMe }
@@ -47,12 +53,18 @@ struct MemberList: View {
 /// "나" 영역. 공통 멤버 행에 좌우 패딩과 카드 배경을 더한다.
 private struct MeArea: View {
     let member: GroupDetailMember
+    let onCardTap: () -> Void
     let onAttendanceTap: () -> Void
 
     var body: some View {
-        MemberRow(member: member, isMe: true, onAttendanceTap: onAttendanceTap)
-            .padding(.horizontal, Spacing.spacing300)
-            .memberCardBackground()
+        MemberRow(
+            member: member,
+            isMe: true,
+            onCardTap: onCardTap,
+            onAttendanceTap: onAttendanceTap
+        )
+        .padding(.horizontal, Spacing.spacing300)
+        .memberCardBackground()
     }
 }
 
@@ -70,7 +82,7 @@ private struct MembersListArea: View {
                 .padding(.horizontal, Spacing.spacing100)
 
             ForEach(members) { member in
-                MemberRow(member: member, isMe: false, onAttendanceTap: {})
+                MemberRow(member: member, isMe: false, onCardTap: {}, onAttendanceTap: {})
             }
         }
         .padding(Spacing.spacing300)
@@ -84,28 +96,12 @@ private struct MembersListArea: View {
 private struct MemberRow: View {
     let member: GroupDetailMember
     let isMe: Bool
+    let onCardTap: () -> Void
     let onAttendanceTap: () -> Void
 
     var body: some View {
         HStack(spacing: Spacing.spacing200) {
-            HStack(spacing: Spacing.spacing250) {
-                Asset(assetType: .image(profileImage), size: .s40, isSelected: false)
-
-                VStack(alignment: .leading, spacing: Spacing.spacing100) {
-                    HStack(spacing: Spacing.spacing100) {
-                        BangawoText(member.nickname, textStyle: .titleMedium)
-                            .foregroundStyle(Colors.gray900)
-
-                        if isMe {
-                            MeChip()
-                        }
-                    }
-
-                    BangawoText(departureLabel, textStyle: .bodyMedium)
-                        .foregroundStyle(Colors.gray700)
-                }
-                .frame(maxWidth: .infinity, alignment: .leading)
-            }
+            cardContent
 
             AttendanceBadge(
                 status: member.attendanceStatus,
@@ -113,8 +109,46 @@ private struct MemberRow: View {
                 isInteractive: isMe,
                 onTap: onAttendanceTap
             )
+            .padding(.vertical, Spacing.spacing300)
         }
-        .padding(.vertical, Spacing.spacing300)
+    }
+
+    @ViewBuilder
+    private var cardContent: some View {
+        if isMe {
+            Button(action: onCardTap) {
+                memberInfo
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.vertical, Spacing.spacing300)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+        } else {
+            memberInfo
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.vertical, Spacing.spacing300)
+        }
+    }
+
+    private var memberInfo: some View {
+        HStack(spacing: Spacing.spacing250) {
+            Asset(assetType: .image(profileImage), size: .s40, isSelected: false)
+
+            VStack(alignment: .leading, spacing: Spacing.spacing100) {
+                HStack(spacing: Spacing.spacing100) {
+                    BangawoText(member.nickname, textStyle: .titleMedium)
+                        .foregroundStyle(Colors.gray900)
+
+                    if isMe {
+                        MeChip()
+                    }
+                }
+
+                BangawoText(departureLabel, textStyle: .bodyMedium)
+                    .foregroundStyle(Colors.gray700)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
     }
 
     /// 기본 출발지(없으면 첫 출발지)의 장소명. 출발지가 없으면 안내 문구를 노출한다.

--- a/Projects/Presentation/HomeFeature/Sources/GroupDetail/Tabs/HomeTab/MyAttendanceStatusEditSheetContent.swift
+++ b/Projects/Presentation/HomeFeature/Sources/GroupDetail/Tabs/HomeTab/MyAttendanceStatusEditSheetContent.swift
@@ -1,0 +1,112 @@
+//
+//  MyAttendanceStatusEditSheetContent.swift
+//  HomeFeature
+//
+
+import SwiftUI
+
+import DesignSystem
+import Entity
+
+struct MyAttendanceStatusEditSheetContent: View {
+    let selectedStatus: AttendanceStatus?
+    let onSelect: (AttendanceStatus) -> Void
+
+    var body: some View {
+        VStack(spacing: Spacing.spacing200) {
+            ForEach(Constant.statusOptions, id: \.rawValue) { status in
+                AttendanceStatusOptionRow(
+                    status: status,
+                    isSelected: selectedStatus == status,
+                    onTap: { onSelect(status) }
+                )
+            }
+        }
+        .padding(.horizontal, Metric.horizontalPadding)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private enum Metric {
+        static let horizontalPadding: CGFloat = -Spacing.spacing250
+    }
+}
+
+// MARK: - AttendanceStatusOptionRow
+
+private struct AttendanceStatusOptionRow: View {
+    let status: AttendanceStatus
+    let isSelected: Bool
+    let onTap: () -> Void
+
+    var body: some View {
+        Button(action: onTap) {
+            HStack(spacing: Spacing.spacing250) {
+                status.icon
+                    .resizable()
+                    .frame(width: Metric.iconLength, height: Metric.iconLength)
+                    .background(
+                        Circle()
+                            .fill(status.iconBackgroundColor)
+                            .frame(width: Metric.iconBackgroundLength, height: Metric.iconBackgroundLength)
+                    )
+                    .frame(width: Metric.iconBackgroundLength, height: Metric.iconBackgroundLength)
+
+                BangawoText(status.displayLabel, textStyle: .bodyLargeEmphasized)
+                    .foregroundStyle(Colors.gray900)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                checkboxIcon
+                    .resizable()
+                    .renderingMode(.template)
+                    .frame(width: Metric.checkboxLength, height: Metric.checkboxLength)
+                    .foregroundStyle(isSelected ? Colors.gray800 : Colors.gray500)
+            }
+            .padding(Metric.contentPadding)
+            .background(
+                RoundedRectangle(cornerRadius: BorderRadius.borderRadius300)
+                    .fill(isSelected ? Colors.grayAlpha100 : Color.clear)
+            )
+            .contentShape(
+                RoundedRectangle(cornerRadius: BorderRadius.borderRadius300)
+            )
+        }
+        .buttonStyle(.plain)
+    }
+
+    private enum Metric {
+        static let iconLength: CGFloat = 24
+        static let iconBackgroundLength: CGFloat = 32
+        static let checkboxLength: CGFloat = 24
+        static let contentPadding: CGFloat = 16
+    }
+
+    private var checkboxIcon: Image {
+        isSelected ? Image.Asset.icCheckboxGhostEnabledMd : Image.Asset.icCheckboxGhostDisabledMd
+    }
+}
+
+private extension AttendanceStatus {
+    var icon: Image {
+        switch self {
+        case .join: return Image.Asset.icDotGreen24
+        case .late: return Image.Asset.icDotOrange24
+        case .absent: return Image.Asset.icDotRed24
+        case .unknown: return Image.Asset.icDotGray16
+        }
+    }
+
+    var iconBackgroundColor: Color {
+        switch self {
+        case .join: return Colors.green200
+        case .late: return Colors.orange200
+        case .absent: return Colors.red200
+        case .unknown: return Colors.gray200
+        }
+    }
+}
+
+// MARK: - Constant
+
+private enum Constant {
+    static let statusOptions: [AttendanceStatus] = [.join, .absent, .late]
+}

--- a/Projects/Presentation/HomeFeature/Sources/GroupDetail/Tabs/HomeTab/MyDeparturePlaceEditSheetContent.swift
+++ b/Projects/Presentation/HomeFeature/Sources/GroupDetail/Tabs/HomeTab/MyDeparturePlaceEditSheetContent.swift
@@ -1,0 +1,23 @@
+//
+//  MyDeparturePlaceEditSheetContent.swift
+//  HomeFeature
+//
+
+import SwiftUI
+
+import ComposableArchitecture
+import DesignSystem
+
+struct MyDeparturePlaceEditSheetContent: View {
+    let store: StoreOf<HomeTabFeature>
+    
+    var body: some View{
+        VStack(spacing: 0) {
+            HStack(spacing: Spacing.spacing200) {
+                BangawoText("출발지 입력", textStyle: .titleLarge)
+                    .foregroundStyle(Color.gray900)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+    }
+}

--- a/Projects/Presentation/HomeFeature/Sources/GroupDetail/Tabs/HomeTab/MyDeparturePlaceEditSheetContent.swift
+++ b/Projects/Presentation/HomeFeature/Sources/GroupDetail/Tabs/HomeTab/MyDeparturePlaceEditSheetContent.swift
@@ -10,14 +10,137 @@ import DesignSystem
 
 struct MyDeparturePlaceEditSheetContent: View {
     let store: StoreOf<HomeTabFeature>
-    
-    var body: some View{
+
+    var body: some View {
         VStack(spacing: 0) {
-            HStack(spacing: Spacing.spacing200) {
-                BangawoText("출발지 입력", textStyle: .titleLarge)
-                    .foregroundStyle(Color.gray900)
+            VStack(spacing: Spacing.spacing200) {
+                ForEach(Constant.departurePlaces) { departurePlace in
+                    DeparturePlaceRow(
+                        stationName: departurePlace.stationName,
+                        address: departurePlace.address,
+                        onEditTap: {}
+                    )
+                }
+
+                AddDeparturePlaceButton(onTap: {})
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(.horizontal, Metric.horizontalPadding)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private enum Metric {
+        static let horizontalPadding: CGFloat = -Spacing.spacing250
+    }
+}
+
+// MARK: - DeparturePlaceRow
+
+private struct DeparturePlaceRow: View {
+    let stationName: String
+    let address: String
+    let onEditTap: () -> Void
+
+    var body: some View {
+        HStack(spacing: Spacing.spacing250) {
+            Image.Asset.icLocation24
+                .resizable()
+                .renderingMode(.template)
+                .frame(width: Metric.iconLength, height: Metric.iconLength)
+                .foregroundStyle(Colors.gray600)
+
+            VStack(alignment: .leading, spacing: Spacing.spacing50) {
+                BangawoText(stationName, textStyle: .bodyMedium)
+                    .foregroundStyle(Colors.gray900)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                BangawoText(address, textStyle: .bodySmall)
+                    .foregroundStyle(Colors.gray700)
                     .frame(maxWidth: .infinity, alignment: .leading)
             }
+
+            Button(action: onEditTap) {
+                BangawoText("수정", textStyle: .labelSmall)
+                    .foregroundStyle(Colors.gray800)
+                    .padding(.horizontal, Spacing.spacing200)
+                    .padding(.vertical, Spacing.spacing100)
+                    .background(
+                        RoundedRectangle(cornerRadius: BorderRadius.borderRadius225)
+                            .fill(Colors.grayAlpha200)
+                    )
+            }
+            .buttonStyle(.plain)
         }
+        .padding(Metric.contentPadding)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: BorderRadius.borderRadius300)
+                .fill(Colors.grayAlpha100)
+        )
+    }
+
+    private enum Metric {
+        static let iconLength: CGFloat = 24
+        static let contentPadding: CGFloat = 16
+    }
+}
+
+// MARK: - AddDeparturePlaceButton
+
+private struct AddDeparturePlaceButton: View {
+    let onTap: () -> Void
+
+    var body: some View {
+        Button(action: onTap) {
+            HStack(spacing: Spacing.spacing250) {
+                Image.Asset.icPlus24
+                    .resizable()
+                    .renderingMode(.template)
+                    .frame(width: Metric.iconLength, height: Metric.iconLength)
+                    .foregroundStyle(Colors.gray700)
+
+                BangawoText("출발지 추가하기", textStyle: .bodyLargeEmphasized)
+                    .foregroundStyle(Colors.gray700)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.all, Metric.allPadding)
+            .background(
+                RoundedRectangle(cornerRadius: BorderRadius.borderRadius300)
+                    .stroke(Colors.gray300, lineWidth: BorderWidth.borderWidth100)
+            )
+        }
+        .buttonStyle(.plain)
+    }
+
+    private enum Metric {
+        static let iconLength: CGFloat = 24
+        static let allPadding: CGFloat = 16
+    }
+}
+
+// MARK: - Constant
+
+private enum Constant {
+    static let departurePlaces: [DeparturePlaceItem] = [
+        .init(
+            stationName: "강남역",
+            address: "서울 강남구 강남대로 396"
+        ),
+        .init(
+            stationName: "홍대입구역",
+            address: "서울 마포구 양화로 188"
+        ),
+        .init(
+            stationName: "성수역",
+            address: "서울 성동구 아차산로 100"
+        )
+    ]
+
+    struct DeparturePlaceItem: Identifiable {
+        let stationName: String
+        let address: String
+
+        var id: String { stationName }
     }
 }

--- a/Projects/Presentation/HomeFeature/Sources/GroupDetail/Tabs/HomeTab/MyDeparturePlaceEditSheetContent.swift
+++ b/Projects/Presentation/HomeFeature/Sources/GroupDetail/Tabs/HomeTab/MyDeparturePlaceEditSheetContent.swift
@@ -5,6 +5,7 @@
 
 import ComposableArchitecture
 import DesignSystem
+import Entity
 import SwiftUI
 import Utill
 
@@ -14,12 +15,12 @@ struct MyDeparturePlaceEditSheetContent: View {
     var body: some View {
         VStack(spacing: Spacing.spacing400) {
             VStack(spacing: Spacing.spacing200) {
-                ForEach(Constant.departurePlaces) { departurePlace in
+                ForEach(departurePlaces) { departurePlace in
                     DeparturePlaceRow(
-                        stationName: departurePlace.stationName,
-                        address: departurePlace.address,
+                        placeName: departurePlace.placeName,
+                        roadAddress: departurePlace.roadAddress,
                         onEditTap: {
-                            Log.debug("수정 버튼 클릭")
+                            Log.debug("출발지 수정 버튼 클릭: \(departurePlace.id)")
                         }
                     )
                 }
@@ -27,7 +28,7 @@ struct MyDeparturePlaceEditSheetContent: View {
             .frame(maxWidth: .infinity, alignment: .leading)
 
             AddDeparturePlaceButton(onTap: {
-                Log.debug("출발지 추가하기 버튼 클릭")
+                store.send(.addDeparturePlaceTapped)
             })
         }
         .padding(.horizontal, Metric.horizontalPadding)
@@ -37,13 +38,17 @@ struct MyDeparturePlaceEditSheetContent: View {
     private enum Metric {
         static let horizontalPadding: CGFloat = -Spacing.spacing250
     }
+
+    private var departurePlaces: [DeparturePlace] {
+        store.groupDetail?.members.first(where: \.isMe)?.departurePlaces ?? []
+    }
 }
 
 // MARK: - DeparturePlaceRow
 
 private struct DeparturePlaceRow: View {
-    let stationName: String
-    let address: String
+    let placeName: String
+    let roadAddress: String
     let onEditTap: () -> Void
 
     var body: some View {
@@ -55,11 +60,11 @@ private struct DeparturePlaceRow: View {
                 .foregroundStyle(Colors.gray600)
 
             VStack(alignment: .leading, spacing: Spacing.spacing50) {
-                BangawoText(stationName, textStyle: .bodyMedium)
+                BangawoText(placeName, textStyle: .bodyMedium)
                     .foregroundStyle(Colors.gray900)
                     .frame(maxWidth: .infinity, alignment: .leading)
 
-                BangawoText(address, textStyle: .bodySmall)
+                BangawoText(roadAddress, textStyle: .bodySmall)
                     .foregroundStyle(Colors.gray700)
                     .frame(maxWidth: .infinity, alignment: .leading)
             }
@@ -123,33 +128,5 @@ private struct AddDeparturePlaceButton: View {
     private enum Metric {
         static let iconLength: CGFloat = 24
         static let allPadding: CGFloat = 16
-    }
-}
-
-// MARK: - Constant
-
-private enum Constant {
-    static let departurePlaces: [DeparturePlaceItem] = [
-        .init(
-            stationName: "강남역",
-            address: "서울 강남구 강남대로 396"
-        ),
-        .init(
-            stationName: "홍대입구역",
-            address: "서울 마포구 양화로 188"
-        ),
-        .init(
-            stationName: "성수역",
-            address: "서울 성동구 아차산로 100"
-        )
-    ]
-
-    struct DeparturePlaceItem: Identifiable {
-        let stationName: String
-        let address: String
-
-        var id: String {
-            stationName
-        }
     }
 }

--- a/Projects/Presentation/HomeFeature/Sources/GroupDetail/Tabs/HomeTab/MyDeparturePlaceEditSheetContent.swift
+++ b/Projects/Presentation/HomeFeature/Sources/GroupDetail/Tabs/HomeTab/MyDeparturePlaceEditSheetContent.swift
@@ -21,6 +21,7 @@ struct MyDeparturePlaceEditSheetContent: View {
                         roadAddress: departurePlace.roadAddress,
                         onEditTap: {
                             Log.debug("출발지 수정 버튼 클릭: \(departurePlace.id)")
+                            store.send(.editDeparturePlaceTapped(id: departurePlace.id))
                         }
                     )
                 }

--- a/Projects/Presentation/HomeFeature/Sources/GroupDetail/Tabs/HomeTab/MyDeparturePlaceEditSheetContent.swift
+++ b/Projects/Presentation/HomeFeature/Sources/GroupDetail/Tabs/HomeTab/MyDeparturePlaceEditSheetContent.swift
@@ -19,6 +19,10 @@ struct MyDeparturePlaceEditSheetContent: View {
                     DeparturePlaceRow(
                         placeName: departurePlace.placeName,
                         roadAddress: departurePlace.roadAddress,
+                        isSelected: departurePlace.isDefault,
+                        onTap: {
+                            store.send(.departurePlaceCardTapped(id: departurePlace.id))
+                        },
                         onEditTap: {
                             Log.debug("출발지 수정 버튼 클릭: \(departurePlace.id)")
                             store.send(.editDeparturePlaceTapped(id: departurePlace.id))
@@ -50,25 +54,35 @@ struct MyDeparturePlaceEditSheetContent: View {
 private struct DeparturePlaceRow: View {
     let placeName: String
     let roadAddress: String
+    let isSelected: Bool
+    let onTap: () -> Void
     let onEditTap: () -> Void
 
     var body: some View {
         HStack(spacing: Spacing.spacing250) {
-            Image.Asset.icLocation24
-                .resizable()
-                .renderingMode(.template)
-                .frame(width: Metric.iconLength, height: Metric.iconLength)
-                .foregroundStyle(Colors.gray600)
+            Button(action: onTap) {
+                HStack(spacing: Spacing.spacing250) {
+                    Image.Asset.icLocation24
+                        .resizable()
+                        .renderingMode(.template)
+                        .frame(width: Metric.iconLength, height: Metric.iconLength)
+                        .foregroundStyle(Colors.gray600)
 
-            VStack(alignment: .leading, spacing: Spacing.spacing50) {
-                BangawoText(placeName, textStyle: .bodyMedium)
-                    .foregroundStyle(Colors.gray900)
-                    .frame(maxWidth: .infinity, alignment: .leading)
+                    VStack(alignment: .leading, spacing: Spacing.spacing50) {
+                        BangawoText(placeName, textStyle: .bodyMedium)
+                            .foregroundStyle(Colors.gray900)
+                            .frame(maxWidth: .infinity, alignment: .leading)
 
-                BangawoText(roadAddress, textStyle: .bodySmall)
-                    .foregroundStyle(Colors.gray700)
-                    .frame(maxWidth: .infinity, alignment: .leading)
+                        BangawoText(roadAddress, textStyle: .bodySmall)
+                            .foregroundStyle(Colors.gray700)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                }
+                .contentShape(Rectangle())
+                .frame(maxWidth: .infinity, alignment: .leading)
             }
+            .buttonStyle(.plain)
+            .frame(maxWidth: .infinity, alignment: .leading)
 
             Button(action: onEditTap) {
                 BangawoText("수정", textStyle: .labelSmall)
@@ -86,7 +100,7 @@ private struct DeparturePlaceRow: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(
             RoundedRectangle(cornerRadius: BorderRadius.borderRadius300)
-                .fill(Colors.grayAlpha100)
+                .fill(isSelected ? Colors.grayAlpha100 : Color.clear)
         )
     }
 

--- a/Projects/Presentation/HomeFeature/Sources/GroupDetail/Tabs/HomeTab/MyDeparturePlaceEditSheetContent.swift
+++ b/Projects/Presentation/HomeFeature/Sources/GroupDetail/Tabs/HomeTab/MyDeparturePlaceEditSheetContent.swift
@@ -3,28 +3,32 @@
 //  HomeFeature
 //
 
-import SwiftUI
-
 import ComposableArchitecture
 import DesignSystem
+import SwiftUI
+import Utill
 
 struct MyDeparturePlaceEditSheetContent: View {
     let store: StoreOf<HomeTabFeature>
 
     var body: some View {
-        VStack(spacing: 0) {
+        VStack(spacing: Spacing.spacing400) {
             VStack(spacing: Spacing.spacing200) {
                 ForEach(Constant.departurePlaces) { departurePlace in
                     DeparturePlaceRow(
                         stationName: departurePlace.stationName,
                         address: departurePlace.address,
-                        onEditTap: {}
+                        onEditTap: {
+                            Log.debug("수정 버튼 클릭")
+                        }
                     )
                 }
-
-                AddDeparturePlaceButton(onTap: {})
             }
             .frame(maxWidth: .infinity, alignment: .leading)
+
+            AddDeparturePlaceButton(onTap: {
+                Log.debug("출발지 추가하기 버튼 클릭")
+            })
         }
         .padding(.horizontal, Metric.horizontalPadding)
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -109,6 +113,9 @@ private struct AddDeparturePlaceButton: View {
                 RoundedRectangle(cornerRadius: BorderRadius.borderRadius300)
                     .stroke(Colors.gray300, lineWidth: BorderWidth.borderWidth100)
             )
+            .contentShape(
+                RoundedRectangle(cornerRadius: BorderRadius.borderRadius300)
+            )
         }
         .buttonStyle(.plain)
     }
@@ -141,6 +148,8 @@ private enum Constant {
         let stationName: String
         let address: String
 
-        var id: String { stationName }
+        var id: String {
+            stationName
+        }
     }
 }

--- a/Projects/Presentation/HomeFeature/Sources/Home/HomeFeature.swift
+++ b/Projects/Presentation/HomeFeature/Sources/Home/HomeFeature.swift
@@ -29,6 +29,11 @@ public struct HomeFeature {
         case design2
     }
 
+    enum DeparturePlaceSearchPurpose: Equatable {
+        case add
+        case edit(id: Int)
+    }
+
     @ObservableState
     public struct State: Equatable {
         public var groups: [Group] = []
@@ -36,6 +41,7 @@ public struct HomeFeature {
         public var hasUnreadNotifications: Bool = false
         public var inviteCardDesign: InviteCardDesign = .design1
         public var isInviteCardDismissed: Bool = false
+        var departurePlaceSearchPurpose: DeparturePlaceSearchPurpose?
         @Presents public var creationView: GroupCreationFeature.State?
         public var path: StackState<Path.State> = StackState<Path.State>()
 
@@ -60,6 +66,7 @@ public struct HomeFeature {
         case inviteCardCloseButtonTapped
         case inviteButtonTapped
         case addDeparturePlaceResponse(Result<DeparturePlace, Error>)
+        case updateDeparturePlaceResponse(Result<DeparturePlace, Error>)
         case creationView(PresentationAction<GroupCreationFeature.Action>)
         case path(StackActionOf<Path>)
     }
@@ -119,13 +126,18 @@ public struct HomeFeature {
 
             case .addDeparturePlaceResponse(.success):
                 Log.debug("출발지 추가 성공")
-                state.path.removeLast()
-
-                guard let detailID = state.currentDetailID else { return .none }
-                return .send(.path(.element(id: detailID, action: .detail(.home(.onAppear)))))
+                return finishDeparturePlaceSearch(state: &state)
 
             case let .addDeparturePlaceResponse(.failure(error)):
                 Log.debug("출발지 추가 실패: \(error)")
+                return .none
+
+            case .updateDeparturePlaceResponse(.success):
+                Log.debug("출발지 수정 성공")
+                return finishDeparturePlaceSearch(state: &state)
+
+            case let .updateDeparturePlaceResponse(.failure(error)):
+                Log.debug("출발지 수정 실패: \(error)")
                 return .none
 
             case let .creationView(.presented(.delegate(.groupCreated(group)))):
@@ -145,29 +157,59 @@ public struct HomeFeature {
                 return .none
 
             case .path(.element(id: _, action: .detail(.delegate(.departurePlaceStationSearchRequested)))):
+                state.departurePlaceSearchPurpose = .add
+                state.path.append(.stationSearch(StationSearchSheetFeature.State()))
+                return .none
+
+            case let .path(.element(id: _, action: .detail(.delegate(.departurePlaceEditStationSearchRequested(id))))):
+                state.departurePlaceSearchPurpose = .edit(id: id)
                 state.path.append(.stationSearch(StationSearchSheetFeature.State()))
                 return .none
 
             case let .path(.element(id: _, action: .stationSearch(.delegate(.stationSelected(station))))):
                 Log.debug("출발지 역 선택: \(station.name)")
                 let client = departurePlaceClient
-                return .run { send in
-                    await send(.addDeparturePlaceResponse(
-                        Result {
-                            try await client.addDeparturePlace(
-                                station.name,
-                                station.addressName,
-                                station.roadAddressName,
-                                station.name,
-                                station.y,
-                                station.x,
-                                true
-                            )
-                        }
-                    ))
+                switch state.departurePlaceSearchPurpose {
+                case .add:
+                    return .run { send in
+                        await send(.addDeparturePlaceResponse(
+                            Result {
+                                try await client.addDeparturePlace(
+                                    station.name,
+                                    station.addressName,
+                                    station.roadAddressName,
+                                    station.name,
+                                    station.y,
+                                    station.x,
+                                    true
+                                )
+                            }
+                        ))
+                    }
+
+                case let .edit(id):
+                    return .run { send in
+                        await send(.updateDeparturePlaceResponse(
+                            Result {
+                                try await client.updateDeparturePlace(
+                                    id,
+                                    station.name,
+                                    station.addressName,
+                                    station.roadAddressName,
+                                    station.name,
+                                    station.y,
+                                    station.x
+                                )
+                            }
+                        ))
+                    }
+
+                case nil:
+                    return .none
                 }
 
             case .path(.element(id: _, action: .stationSearch(.delegate(.dismissed)))):
+                state.departurePlaceSearchPurpose = nil
                 state.path.removeLast()
                 return .none
 
@@ -198,6 +240,14 @@ public struct HomeFeature {
                 Result { try await client.fetchGroups() }
             ))
         }
+    }
+
+    private func finishDeparturePlaceSearch(state: inout State) -> Effect<Action> {
+        state.departurePlaceSearchPurpose = nil
+        state.path.removeLast()
+
+        guard let detailID = state.currentDetailID else { return .none }
+        return .send(.path(.element(id: detailID, action: .detail(.home(.onAppear)))))
     }
 
     private func updateDateVoteStatus(

--- a/Projects/Presentation/HomeFeature/Sources/Home/HomeFeature.swift
+++ b/Projects/Presentation/HomeFeature/Sources/Home/HomeFeature.swift
@@ -8,16 +8,20 @@ import Foundation
 import ComposableArchitecture
 import CoreDependencies
 import Entity
+import StationSearchFeature
+import Utill
 
 @Reducer
 public struct HomeFeature {
     @Dependency(\.groupClient) private var groupClient
+    @Dependency(\.departurePlaceClient) private var departurePlaceClient
     @Dependency(\.withRandomNumberGenerator) private var withRandomNumberGenerator
 
     @Reducer(state: .equatable)
     public enum Path {
         case detail(GroupDetailFeature)
         case dateSelection(MeetingDateSelectionFeature)
+        case stationSearch(StationSearchSheetFeature)
     }
 
     public enum InviteCardDesign: Equatable, CaseIterable, Sendable {
@@ -55,6 +59,7 @@ public struct HomeFeature {
         case groupCardTapped(Group)
         case inviteCardCloseButtonTapped
         case inviteButtonTapped
+        case addDeparturePlaceResponse(Result<DeparturePlace, Error>)
         case creationView(PresentationAction<GroupCreationFeature.Action>)
         case path(StackActionOf<Path>)
     }
@@ -112,6 +117,17 @@ public struct HomeFeature {
                 // TODO: 친구 초대/링크 공유 플로우 연결
                 return .none
 
+            case .addDeparturePlaceResponse(.success):
+                Log.debug("출발지 추가 성공")
+                state.path.removeLast()
+
+                guard let detailID = state.currentDetailID else { return .none }
+                return .send(.path(.element(id: detailID, action: .detail(.home(.onAppear)))))
+
+            case let .addDeparturePlaceResponse(.failure(error)):
+                Log.debug("출발지 추가 실패: \(error)")
+                return .none
+
             case let .creationView(.presented(.delegate(.groupCreated(group)))):
                 state.creationView = nil
                 state.path.append(.detail(GroupDetailFeature.State(group: group)))
@@ -126,6 +142,33 @@ public struct HomeFeature {
 
             case let .path(.element(id: _, action: .detail(.delegate(.meetingDateSelectionRequested(meetingId))))):
                 state.path.append(.dateSelection(MeetingDateSelectionFeature.State(meetingId: meetingId)))
+                return .none
+
+            case .path(.element(id: _, action: .detail(.delegate(.departurePlaceStationSearchRequested)))):
+                state.path.append(.stationSearch(StationSearchSheetFeature.State()))
+                return .none
+
+            case let .path(.element(id: _, action: .stationSearch(.delegate(.stationSelected(station))))):
+                Log.debug("출발지 역 선택: \(station.name)")
+                let client = departurePlaceClient
+                return .run { send in
+                    await send(.addDeparturePlaceResponse(
+                        Result {
+                            try await client.addDeparturePlace(
+                                station.name,
+                                station.addressName,
+                                station.roadAddressName,
+                                station.name,
+                                station.y,
+                                station.x,
+                                true
+                            )
+                        }
+                    ))
+                }
+
+            case .path(.element(id: _, action: .stationSearch(.delegate(.dismissed)))):
+                state.path.removeLast()
                 return .none
 
             case let .path(.element(id: _, action: .dateSelection(.delegate(.dateSelectionCompleted(
@@ -182,6 +225,15 @@ public struct HomeFeature {
         detailState.home.groupDetail = detailState.home.groupDetail?.updating(dateVoteStatus: dateVoteStatus)
         state.path[id: detailID] = .detail(detailState)
         return detailID
+    }
+}
+
+private extension HomeFeature.State {
+    var currentDetailID: StackElementID? {
+        path.ids.last { id in
+            if case .detail = path[id: id] { return true }
+            return false
+        }
     }
 }
 

--- a/Projects/Presentation/HomeFeature/Sources/Home/HomeView.swift
+++ b/Projects/Presentation/HomeFeature/Sources/Home/HomeView.swift
@@ -8,6 +8,7 @@ import SwiftUI
 import ComposableArchitecture
 import DesignSystem
 import Entity
+import StationSearchFeature
 
 public struct HomeView: View {
     @Bindable private var store: StoreOf<HomeFeature>
@@ -91,6 +92,9 @@ public struct HomeView: View {
 
             case let .dateSelection(dateSelectionStore):
                 MeetingDateSelectionView(store: dateSelectionStore)
+
+            case let .stationSearch(stationSearchStore):
+                StationSearchSheet(store: stationSearchStore)
             }
         }
     }

--- a/Projects/Presentation/StationSearchFeature/Sources/StationSearch/StationSearchSheet.swift
+++ b/Projects/Presentation/StationSearchFeature/Sources/StationSearch/StationSearchSheet.swift
@@ -10,10 +10,14 @@ import ComposableArchitecture
 import DesignSystem
 import Entity
 
-struct StationSearchSheet: View {
+public struct StationSearchSheet: View {
     @Bindable var store: StoreOf<StationSearchSheetFeature>
 
-    var body: some View {
+    public init(store: StoreOf<StationSearchSheetFeature>) {
+        self.store = store
+    }
+
+    public var body: some View {
         VStack(spacing: 0) {
             NavigationPage(
                 background: .clear,


### PR DESCRIPTION
## 작업 내용

모임 상세 홈 탭에서 내 출발지를 추가/수정할 수 있도록 플로우를 연결했습니다.

### 출발지 추가
- 출발지 수정 바텀시트의 `출발지 추가하기` 버튼 클릭 시 역 검색 화면으로 이동
- 역 선택 시 `/api/v1/departure-places` POST API 호출
- 새로 추가한 출발지는 `isDefault: true`로 요청
- API 성공 후 모임 상세 데이터를 재조회하여 최신 출발지 목록 반영

### 출발지 수정
- 출발지 목록의 각 아이템에 있는 `수정` 버튼 클릭 시 역 검색 화면으로 이동
- 수정 대상 출발지의 `id`를 유지한 상태로 역 검색 진행
- 역 선택 시 `/api/v1/departure-places/{id}` PUT API 호출
- API 성공 후 모임 상세 데이터를 재조회하여 변경된 출발지 정보 반영

### 역 검색 화면 연결 방식 변경
- 기존 바텀시트 방식이 아닌 `NavigationStack` 기반 화면 전환으로 변경
- `StationSearchSheet`는 검색/선택 역할만 유지
- 추가/수정 여부와 API 호출은 `HomeFeature`에서 관리하도록 분리

### 기타
- 모임 참석여부 플로우 연동
- 출발지 수정 바텀시트는 서버에서 내려오는 `members[].departurePlaces` 데이터를 사용하도록 정리
- 내 출발지 영역은 텍스트 + arrow 아이콘 버튼을 통해서만 수정 바텀시트가 열리도록 변경

