### PR TITLE
[REFACTOR] 추천장소 담기·장소 투표 디자인 정리

### DIFF
--- a/Projects/Data/Model/Sources/PlacePickStatusDTO.swift
+++ b/Projects/Data/Model/Sources/PlacePickStatusDTO.swift
@@ -12,6 +12,8 @@ public struct PlacePickStatusResponseDTO: Decodable, Sendable {
     public struct MemberDTO: Decodable, Sendable {
         public let memberId: Int
         public let nickname: String
+        public let profileImageUrl: String?
+        public let isMe: Bool
         public let done: Bool
     }
 
@@ -27,7 +29,13 @@ public extension PlacePickStatusResponseDTO {
     func toEntity() -> PlacePickStatus {
         PlacePickStatus(
             members: members.map {
-                PlacePickStatus.Member(memberId: $0.memberId, nickname: $0.nickname, done: $0.done)
+                PlacePickStatus.Member(
+                    memberId: $0.memberId,
+                    nickname: $0.nickname,
+                    profileImageUrl: $0.profileImageUrl,
+                    isMe: $0.isMe,
+                    done: $0.done
+                )
             },
             myPicks: myPicks.map {
                 PlacePickStatus.PickedPlaceSummary(

--- a/Projects/Domain/Entity/Sources/PlacePick/PlacePickStatus.swift
+++ b/Projects/Domain/Entity/Sources/PlacePick/PlacePickStatus.swift
@@ -19,13 +19,17 @@ public struct PlacePickStatus: Equatable, Sendable {
     public struct Member: Equatable, Sendable, Identifiable {
         public let memberId: Int
         public let nickname: String
+        public let profileImageUrl: String?
+        public let isMe: Bool
         public let done: Bool
 
         public var id: Int { memberId }
 
-        public init(memberId: Int, nickname: String, done: Bool) {
+        public init(memberId: Int, nickname: String, profileImageUrl: String? = nil, isMe: Bool = false, done: Bool) {
             self.memberId = memberId
             self.nickname = nickname
+            self.profileImageUrl = profileImageUrl
+            self.isMe = isMe
             self.done = done
         }
     }

--- a/Projects/Presentation/HomeFeature/Sources/Common/PlaceRow.swift
+++ b/Projects/Presentation/HomeFeature/Sources/Common/PlaceRow.swift
@@ -220,7 +220,7 @@ private struct PlaceTagChip: View {
             .padding(.horizontal, Spacing.spacing150)
             .padding(.vertical, Spacing.spacing100)
             .background(
-                RoundedRectangle(cornerRadius: BorderRadius.borderRadius150)
+                Capsule()
                     .fill(backgroundColor)
             )
     }

--- a/Projects/Presentation/HomeFeature/Sources/Common/PlaceRow.swift
+++ b/Projects/Presentation/HomeFeature/Sources/Common/PlaceRow.swift
@@ -69,9 +69,9 @@ struct PlaceRow<Trailing: View>: View {
                         .foregroundStyle(Color.gray800)
 
                     HStack(spacing: Spacing.spacing225) {
-                        Text("18km")
-                            .pretendardCustomFont(textStyle: .bodyMedium)
-                            .foregroundStyle(Color.gray600)
+//                        Text("18km")
+//                            .pretendardCustomFont(textStyle: .bodyMedium)
+//                            .foregroundStyle(Color.gray600)
 
                         Button {
                             toggleTooltip()

--- a/Projects/Presentation/HomeFeature/Sources/GroupDetail/GroupDetailView.swift
+++ b/Projects/Presentation/HomeFeature/Sources/GroupDetail/GroupDetailView.swift
@@ -43,7 +43,6 @@ public struct GroupDetailView: View {
         }
         .background(Colors.gray200)
         .toolbar(.hidden, for: .navigationBar)
-        .task { store.send(.home(.onAppear)) }
     }
 
     private var tabBinding: Binding<Int> {
@@ -60,16 +59,22 @@ private struct TabContent: View {
     let store: StoreOf<GroupDetailFeature>
 
     var body: some View {
-        if store.home.isLoading {
-            ProgressView()
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-        } else {
+        Group {
             switch store.selectedTab {
             case .home:
                 HomeTab(store: store.scope(state: \.home, action: \.home))
 
             case .myPlace:
                 MyPlaceTab(store: store.scope(state: \.myPlace, action: \.myPlace))
+            }
+        }
+        // HomeTab을 트리에서 제거하지 않고 위에 덮는다.
+        // 최초 로드에만 노출되며, HomeTab의 .task 재마운트 루프를 유발하지 않는다.
+        .overlay {
+            if store.home.isLoading {
+                ProgressView()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .background(Colors.gray200)
             }
         }
     }

--- a/Projects/Presentation/HomeFeature/Sources/GroupDetail/PlaceVoteParticipation/PlaceVoteParticipantsView.swift
+++ b/Projects/Presentation/HomeFeature/Sources/GroupDetail/PlaceVoteParticipation/PlaceVoteParticipantsView.swift
@@ -8,6 +8,7 @@ import SwiftUI
 
 import ComposableArchitecture
 
+import CoreDependencies
 import DesignSystem
 import Entity
 
@@ -29,20 +30,29 @@ struct PlaceVoteParticipantsView: View {
             )
 
             ScrollView {
-                VStack(alignment: .leading, spacing: Spacing.spacing400) {
-                    BangawoText("현재 참여 중인 팀원", textStyle: .titleMedium)
-                        .foregroundStyle(Colors.gray900)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-
+                VStack(alignment: .leading, spacing: 0) {
+                    Header()
                     ParticipantsList(participants: store.participants)
                 }
-                .padding(.horizontal, Spacing.spacing400)
-                .padding(.top, Spacing.spacing200)
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(Colors.gray00)
         .task { store.send(.task) }
+    }
+}
+
+// MARK: - Header
+
+/// 장소 투표 참여 현황 타이틀.
+private struct Header: View {
+    var body: some View {
+        BangawoText("현재 참여중인 팀원", textStyle: .titleMedium)
+            .foregroundStyle(Colors.gray900)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.top, Spacing.spacing300)
+            .padding(.bottom, Spacing.spacing200)
+            .padding(.horizontal, Spacing.spacing400)
     }
 }
 
@@ -54,15 +64,28 @@ private struct ParticipantsList: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            BangawoText("팀원 \(participants.count)명", textStyle: .bodySmall)
-                .foregroundStyle(Colors.gray800)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.horizontal, Spacing.spacing100)
+            ListHeader(count: participants.count)
 
             ForEach(participants) { participant in
                 ParticipantRow(participant: participant)
             }
         }
+        .padding(.vertical, Spacing.spacing300)
+        .padding(.horizontal, Spacing.spacing400)
+    }
+}
+
+// MARK: - List Header
+
+/// 참여 팀원 수를 표시하는 리스트 헤더.
+private struct ListHeader: View {
+    let count: Int
+
+    var body: some View {
+        BangawoText("팀원 \(count)명", textStyle: .bodySmall)
+            .foregroundStyle(Colors.gray800)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, Spacing.spacing100)
     }
 }
 
@@ -74,53 +97,121 @@ private struct ParticipantRow: View {
 
     var body: some View {
         HStack(spacing: Spacing.spacing200) {
-            HStack(spacing: Spacing.spacing250) {
-                Avatar(avatarType: avatarType, size: .s40)
+            memberInfo
+                .frame(maxWidth: .infinity, alignment: .leading)
 
-                VStack(alignment: .leading, spacing: Spacing.spacing100) {
+            VoteParticipationBadge(isVoteCompleted: participant.voted)
+        }
+        .padding(.vertical, Spacing.spacing300)
+    }
+
+    private var memberInfo: some View {
+        HStack(spacing: Spacing.spacing250) {
+            ProfileAsset(profileImageUrl: participant.profileImageUrl)
+
+            VStack(alignment: .leading, spacing: Spacing.spacing100) {
+                HStack(spacing: Spacing.spacing100) {
                     BangawoText(participant.name, textStyle: .titleMedium)
                         .foregroundStyle(Colors.gray900)
 
-                    BangawoText(departureLabel, textStyle: .bodyMedium)
-                        .foregroundStyle(Colors.gray700)
+                    if participant.isMe {
+                        MeChip()
+                    }
                 }
-                .frame(maxWidth: .infinity, alignment: .leading)
-            }
 
-            VoteParticipationLabel(isVoteCompleted: participant.voted)
+                BangawoText(departureLabel, textStyle: .bodyMedium)
+                    .foregroundStyle(Colors.gray700)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
-        .padding(.vertical, Spacing.spacing300)
     }
 
     /// 출발지명. 없으면 안내 문구를 노출한다.
     private var departureLabel: String {
         participant.departureName ?? Constant.emptyDepartureLabel
     }
+}
 
-    private var avatarType: Avatar.AvatarType {
-        guard
-            let urlString = participant.profileImageUrl,
-            let url = URL(string: urlString)
-        else { return .placeholder }
+// MARK: - Profile Asset
 
-        return .image(url)
+/// 프로필 이미지를 Asset 컴포넌트 사이즈에 맞춰 노출한다.
+private struct ProfileAsset: View {
+    let profileImageUrl: String?
+
+    var body: some View {
+        AsyncImage(url: profileImageUrl.flatMap(URL.init(string:))) { phase in
+            switch phase {
+            case .success(let image):
+                Asset(assetType: .image(image), size: .s40, isSelected: false)
+
+            default:
+                Asset(assetType: .image(Image.Asset.imgAvatarPlaceholder), size: .s40, isSelected: false)
+            }
+        }
     }
 }
 
-// MARK: - Vote Participation Label
+// MARK: - Me Chip
+
+/// 멤버 이름 우측에 붙는 "나" 라벨 칩.
+private struct MeChip: View {
+    var body: some View {
+        BangawoText("나", textStyle: .bodySmall)
+            .foregroundStyle(Colors.gray700)
+            .padding(.vertical, Metric.meChipVerticalPadding)
+            .padding(.horizontal, Spacing.spacing200)
+            .overlay(
+                Capsule()
+                    .stroke(Colors.gray400, lineWidth: BorderWidth.borderWidth100)
+            )
+    }
+}
+
+// MARK: - Vote Participation Badge
 
 /// 멤버의 투표 참여 여부 라벨. 완료는 강조, 미참여는 흐린 색으로 구분한다.
-private struct VoteParticipationLabel: View {
+private struct VoteParticipationBadge: View {
     let isVoteCompleted: Bool
 
     var body: some View {
-        BangawoText(isVoteCompleted ? "투표 완료" : "미참여", textStyle: .bodyMedium)
-            .foregroundStyle(isVoteCompleted ? Colors.gray800 : Colors.gray500)
+        Badge(
+            isVoteCompleted ? "투표 완료" : "미참여",
+            variant: isVoteCompleted ? .solid : .outline,
+            size: .medium
+        )
     }
 }
 
 // MARK: - Constants
 
+private enum Metric {
+    static let meChipVerticalPadding: CGFloat = 3
+}
+
 private enum Constant {
     static let emptyDepartureLabel = "출발지 미설정"
 }
+
+// MARK: - Preview
+
+#if DEBUG
+private func makePlaceVoteParticipantsStore() -> StoreOf<PlaceVoteParticipantsFeature> {
+    var state = PlaceVoteParticipantsFeature.State(meetingId: 1)
+    state.participants = VoteClient.previewPlaceVoteParticipants
+
+    return Store(initialState: state) {
+        PlaceVoteParticipantsFeature()
+    } withDependencies: {
+        $0.voteClient = .previewValue
+    }
+}
+
+#Preview("기본") {
+    BangawoPreview {
+        PlaceVoteParticipantsView(
+            store: makePlaceVoteParticipantsStore(),
+            onClose: {}
+        )
+    }
+}
+#endif

--- a/Projects/Presentation/HomeFeature/Sources/GroupDetail/PlaceVoteParticipation/PlaceVoteParticipationView.swift
+++ b/Projects/Presentation/HomeFeature/Sources/GroupDetail/PlaceVoteParticipation/PlaceVoteParticipationView.swift
@@ -61,7 +61,6 @@ struct PlaceVoteParticipationView: View {
                     store: store,
                     onFocusPlace: { focusedCoordinate = $0 }
                 )
-                .padding(.horizontal, Spacing.spacing400)
             }
             .onVisibleHeightChanged { sheetCoveredHeight = $0 }
 

--- a/Projects/Presentation/HomeFeature/Sources/GroupDetail/PlaceVoteParticipation/PlaceVoteSheetContent.swift
+++ b/Projects/Presentation/HomeFeature/Sources/GroupDetail/PlaceVoteParticipation/PlaceVoteSheetContent.swift
@@ -19,23 +19,18 @@ struct PlaceVoteSheetContent: View {
     let onFocusPlace: (MapCoordinate) -> Void
 
     var body: some View {
-        VStack(alignment: .leading, spacing: Spacing.spacing300) {
+        VStack(alignment: .leading, spacing: 0) {
             PlaceVoteHeader(store: store)
 
-            VStack(spacing: Spacing.spacing200) {
-                ForEach(store.candidates) { candidate in
-                    PlaceVoteRow(
-                        candidate: candidate,
-                        mode: store.mode,
-                        isSelected: store.selectedPlaceIds.contains(candidate.id),
-                        isTop: store.topPlaceId == candidate.id,
-                        onTap: { focus(candidate) },
-                        onSelect: { store.send(.placeSelected(candidate.id)) }
-                    )
-                }
-            }
+            PlaceVoteList(
+                candidates: store.candidates,
+                mode: store.mode,
+                selectedPlaceIds: store.selectedPlaceIds,
+                topPlaceId: store.topPlaceId,
+                onTap: { focus($0) },
+                onSelect: { store.send(.placeSelected($0)) }
+            )
         }
-        .padding(.top, Spacing.spacing100)
         .padding(.bottom, UIScreen.safeAreaBottom + PlaceVoteButtonArea.height)
     }
 
@@ -62,21 +57,60 @@ private struct PlaceVoteHeader: View {
             BangawoText("약속 장소 투표하기", textStyle: .titleLarge)
                 .foregroundStyle(Colors.gray800)
 
-            HStack(spacing: 0) {
+            HStack(spacing: Spacing.spacing100) {
                 DeadlineDescription(deadline: store.deadline)
 
                 if store.mode == .voted {
                     Button {
                         store.send(.participantsButtonTapped)
                     } label: {
-                        BangawoText(" · 현재 \(store.votedCount)명 참여", textStyle: .bodySmall)
-                            .foregroundStyle(Colors.gray700)
+                        HStack(spacing: Spacing.spacing100) {
+                            BangawoText("\(store.votedCount)명 참여중", textStyle: .bodyMediumEmphasized)
+                                .foregroundStyle(Colors.gray700)
+
+                            Image.Asset.icArrowSmallRight16
+                                .renderingMode(.template)
+                                .foregroundStyle(Colors.gray700)
+                                .frame(width: 16, height: 16)
+                        }
                     }
                     .buttonStyle(.plain)
                 }
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.top, Spacing.spacing300)
+        .padding(.bottom, Spacing.spacing200)
+        .padding(.horizontal, Spacing.spacing400)
+    }
+}
+
+// MARK: - Place Vote List
+
+private struct PlaceVoteList: View {
+    let candidates: [PlaceVoteCandidate]
+    let mode: PlaceVoteParticipationFeature.Mode
+    let selectedPlaceIds: Set<Int>
+    let topPlaceId: Int?
+    let onTap: (PlaceVoteCandidate) -> Void
+    let onSelect: (Int) -> Void
+
+    var body: some View {
+        VStack(spacing: Spacing.spacing250) {
+            ForEach(candidates) { candidate in
+                PlaceVoteRow(
+                    candidate: candidate,
+                    mode: mode,
+                    isSelected: selectedPlaceIds.contains(candidate.id),
+                    isTop: topPlaceId == candidate.id,
+                    onTap: { onTap(candidate) },
+                    onSelect: { onSelect(candidate.id) }
+                )
+            }
+        }
+        .padding(.top, Spacing.spacing300)
+        .padding(.bottom, Spacing.spacing400)
+        .padding(.horizontal, Spacing.spacing400)
     }
 }
 
@@ -135,14 +169,14 @@ private struct PlaceVoteRow: View {
 
     private var backgroundColor: Color {
         if mode == .voted, isTop { return Colors.orange100 }
-        if mode == .voting, isSelected { return Colors.gray200 }
+        if mode == .voting, isSelected { return Colors.gray50 }
 
         return Colors.gray50
     }
 
     private var borderColor: Color {
         if mode == .voted, isTop { return Colors.orange300 }
-        if mode == .voting, isSelected { return Colors.gray300 }
+        if mode == .voting, isSelected { return Colors.gray200 }
 
         return Colors.gray200
     }
@@ -155,14 +189,21 @@ private struct VoteResult: View {
     let voteCount: Int
 
     var body: some View {
-        VStack(alignment: .trailing, spacing: Spacing.spacing50) {
+        VStack(alignment: .trailing, spacing: Spacing.spacing100) {
             if isTop {
-                Badge("1위", variant: .solid, size: .small)
+                BangawoText("1위", textStyle: .labelXSmall)
+                    .foregroundStyle(Colors.gray00)
+                    .padding(.vertical, Spacing.spacing25)
+                    .padding(.horizontal, Spacing.spacing200)
+                    .background(
+                        Capsule().fill(Colors.orange500)
+                    )
             }
 
-            BangawoText("\(voteCount)명 투표", textStyle: .bodySmall)
+            BangawoText("\(voteCount)명 투표", textStyle: .bodyXSmall)
                 .foregroundStyle(Colors.gray700)
         }
+        .padding(.trailing, Spacing.spacing100)
     }
 }
 
@@ -203,6 +244,7 @@ private struct DeadlineDescription: View {
                 }
             }
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
         .onReceive(Countdown.everySecond) { now = $0 }
     }
 

--- a/Projects/Presentation/HomeFeature/Sources/GroupDetail/Tabs/HomeTab/HomeTabFeature.swift
+++ b/Projects/Presentation/HomeFeature/Sources/GroupDetail/Tabs/HomeTab/HomeTabFeature.swift
@@ -162,7 +162,12 @@ public struct HomeTabFeature {
         Reduce { state, action in
             switch action {
             case .onAppear:
-                state.isLoading = true
+                // 최초 진입에만 전체 ProgressView를 노출한다.
+                // 재진입(탭 전환 복귀 등)에서는 isLoading을 건드리지 않고 조용히 갱신해
+                // ProgressView ↔ HomeTab 교체로 인한 재마운트 루프를 막는다.
+                if state.groupDetail == nil {
+                    state.isLoading = true
+                }
                 return .concatenate(
                     .merge(
                         fetchGroupDetailEffect(meetingId: state.group.meetingId),

--- a/Projects/Presentation/HomeFeature/Sources/MeetingDetail/MapBottomSheet/NearbyPlace/NearbyPlaceListSheet.swift
+++ b/Projects/Presentation/HomeFeature/Sources/MeetingDetail/MapBottomSheet/NearbyPlace/NearbyPlaceListSheet.swift
@@ -72,8 +72,6 @@ private struct NearbyPlaceListHeader: View {
                 selectedIndex: store.selectedStationIndex,
                 onSelect: { store.send(.stationSelected($0)) }
             )
-            .padding(.horizontal, Spacing.spacing400)
-            .padding(.bottom, Spacing.spacing250)
         }
     }
 }
@@ -119,24 +117,36 @@ private struct StationSegmentedControl: View {
     let selectedIndex: Int
     let onSelect: (Int) -> Void
 
+    @Namespace private var namespace
+
     var body: some View {
-        ScrollView(.horizontal, showsIndicators: false) {
-            HStack(spacing: Spacing.spacing200) {
-                ForEach(Array(stations.enumerated()), id: \.element.id) { index, station in
-                    StationSegment(
-                        station: station,
-                        isSelected: selectedIndex == index,
-                        onTap: { onSelect(index) }
-                    )
-                }
+        HStack(spacing: 0) {
+            ForEach(Array(stations.enumerated()), id: \.element.id) { index, station in
+                StationSegment(
+                    station: station,
+                    isSelected: selectedIndex == index,
+                    namespace: namespace,
+                    onTap: { withAnimation(.easeInOut) { onSelect(index) } }
+                )
+                .frame(maxWidth: .infinity)
             }
         }
+        .padding(Spacing.spacing100)
+        .background(
+            RoundedRectangle(cornerRadius: BorderRadius.borderRadiusFull)
+                .fill(Colors.gray200)
+        )
+        .frame(maxWidth: .infinity)
+        .padding(.horizontal, Spacing.spacing400)
+        // 9pt: 매칭 디자인 토큰 없음
+        .padding(.bottom, 9)
     }
 }
 
 private struct StationSegment: View {
     let station: MidpointStation
     let isSelected: Bool
+    let namespace: Namespace.ID
     let onTap: () -> Void
 
     var body: some View {
@@ -144,35 +154,49 @@ private struct StationSegment: View {
             HStack(spacing: Spacing.spacing150) {
                 Text("\(station.stationName)역")
                     .pretendardCustomFont(textStyle: .labelMedium)
-                    .foregroundStyle(isSelected ? Colors.gray00 : Colors.gray800)
+                    .foregroundStyle(isSelected ? Colors.gray900 : Colors.gray700)
 
                 if station.rank == 1 {
-                    MiddleBadge(isSelected: isSelected)
+                    MiddleBadge()
                 }
             }
-            .padding(.horizontal, Spacing.spacing300)
+            .padding(.horizontal, Spacing.spacing250)
             .padding(.vertical, Spacing.spacing200)
-            .background(
-                RoundedRectangle(cornerRadius: BorderRadius.borderRadiusFull)
-                    .fill(isSelected ? Colors.gray900 : Colors.gray100)
-            )
+            .frame(maxWidth: .infinity)
+            .background {
+                if isSelected {
+                    RoundedRectangle(cornerRadius: BorderRadius.borderRadiusFull)
+                        .fill(Colors.gray00)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: BorderRadius.borderRadiusFull)
+                                .stroke(Colors.gray50, lineWidth: BorderWidth.borderWidth100)
+                        )
+                        .shadow(
+                            color: BoxShadow.boxShadow100.color,
+                            radius: BoxShadow.boxShadow100.blur / 2,
+                            x: BoxShadow.boxShadow100.offsetX,
+                            y: BoxShadow.boxShadow100.offsetY
+                        )
+                        .matchedGeometryEffect(id: "selectedTab", in: namespace)
+                }
+            }
         }
         .buttonStyle(.plain)
     }
 }
 
 private struct MiddleBadge: View {
-    let isSelected: Bool
-
     var body: some View {
         Text("중간")
-            .pretendardCustomFont(textStyle: .labelXSmall)
-            .foregroundStyle(isSelected ? Colors.gray900 : Colors.gray00)
+            .pretendardFont(family: .Medium, size: 11)
+            .kerning(0.2)
+            .lineSpacing(15 - 11)
+            .foregroundStyle(Colors.gray700)
             .padding(.horizontal, Spacing.spacing150)
-            .padding(.vertical, Spacing.spacing50)
-            .background(
-                RoundedRectangle(cornerRadius: BorderRadius.borderRadius150)
-                    .fill(isSelected ? Colors.gray00 : Colors.gray600)
+            .padding(.vertical, Spacing.spacing25)
+            .overlay(
+                RoundedRectangle(cornerRadius: BorderRadius.borderRadiusFull)
+                    .stroke(Colors.gray400, lineWidth: BorderWidth.borderWidth100)
             )
     }
 }
@@ -184,12 +208,7 @@ private struct PlaceAddButton: View {
     let onTap: () -> Void
 
     var body: some View {
-        BangawoButton(
-            isPicked ? "담음" : "담기",
-            variant: isPicked ? .solid : .weak,
-            size: .xsmall,
-            action: onTap
-        )
+        ToggleButton(isSelected: isPicked, action: onTap)
     }
 }
 
@@ -286,7 +305,7 @@ private struct NearbyPlaceOptionFilterButton: View {
         Button(action: onTap) {
             HStack(spacing: Spacing.spacing100) {
                 Checkbox(
-                    variant: .ghost,
+                    variant: .circle,
                     state: isSelected ? .enabled : .disabled,
                     size: .small
                 )

--- a/Projects/Presentation/HomeFeature/Sources/PickPlace/PickPlaceModels.swift
+++ b/Projects/Presentation/HomeFeature/Sources/PickPlace/PickPlaceModels.swift
@@ -13,6 +13,7 @@ public struct PickPlaceMember: Identifiable, Equatable, Sendable {
     public let id: Int
     public let nickname: String
     public let profileImageUrl: String?
+    public let isMe: Bool
     /// 해당 멤버가 후보 장소를 하나라도 담았는지 여부.
     public let hasPicked: Bool
 
@@ -20,11 +21,13 @@ public struct PickPlaceMember: Identifiable, Equatable, Sendable {
         id: Int,
         nickname: String,
         profileImageUrl: String?,
+        isMe: Bool = false,
         hasPicked: Bool
     ) {
         self.id = id
         self.nickname = nickname
         self.profileImageUrl = profileImageUrl
+        self.isMe = isMe
         self.hasPicked = hasPicked
     }
 }
@@ -60,7 +63,8 @@ public extension PickPlaceMember {
         self.init(
             id: member.id,
             nickname: member.nickname,
-            profileImageUrl: nil,
+            profileImageUrl: member.profileImageUrl,
+            isMe: member.isMe,
             hasPicked: member.done
         )
     }
@@ -92,7 +96,7 @@ public extension PickedPlace {
 
 public extension PickPlaceMember {
     static let mock: [PickPlaceMember] = [
-        PickPlaceMember(id: 1, nickname: "김반가", profileImageUrl: nil, hasPicked: true),
+        PickPlaceMember(id: 1, nickname: "김반가", profileImageUrl: nil, isMe: true, hasPicked: true),
         PickPlaceMember(id: 2, nickname: "이워고", profileImageUrl: nil, hasPicked: true),
         PickPlaceMember(id: 3, nickname: "박장소", profileImageUrl: nil, hasPicked: false),
         PickPlaceMember(id: 4, nickname: "최투표", profileImageUrl: nil, hasPicked: true),

--- a/Projects/Presentation/HomeFeature/Sources/PickPlace/PickPlaceModels.swift
+++ b/Projects/Presentation/HomeFeature/Sources/PickPlace/PickPlaceModels.swift
@@ -109,3 +109,92 @@ public extension PickedPlace {
         PickedPlace(id: 5, name: "광화문브런치", category: .cafe, address: "서울 종로구 종로 1", pickedCount: 1)
     ]
 }
+
+public extension StationRecommendation {
+    /// 장소보기 탭 프리뷰용 더미 역/추천 장소 그룹. rank 1 역에 "중간" 배지가 노출된다.
+    static let mock: [StationRecommendation] = [
+        StationRecommendation(
+            station: MidpointStation(
+                stationId: 1,
+                rank: 1,
+                stationName: "신사",
+                lines: "3호선",
+                distanceKm: 0.4,
+                latitude: 37.5163,
+                longitude: 127.0204
+            ),
+            places: [
+                RecommendedPlace(
+                    rank: 1,
+                    placeId: 101,
+                    name: "감성카페",
+                    categoryLabel: .cafe,
+                    address: "서울 강남구 도산대로 1",
+                    score: 4.5,
+                    nearestStationId: 1,
+                    latitude: 37.5163,
+                    longitude: 127.0204
+                ),
+                RecommendedPlace(
+                    rank: 2,
+                    placeId: 102,
+                    name: "신사다이닝",
+                    categoryLabel: .koreaFood,
+                    address: "서울 강남구 강남대로 2",
+                    score: 4.2,
+                    nearestStationId: 1,
+                    latitude: 37.5165,
+                    longitude: 127.0206
+                )
+            ]
+        ),
+        StationRecommendation(
+            station: MidpointStation(
+                stationId: 2,
+                rank: 2,
+                stationName: "강남",
+                lines: "2호선·신분당선",
+                distanceKm: 0.7,
+                latitude: 37.4979,
+                longitude: 127.0276
+            ),
+            places: [
+                RecommendedPlace(
+                    rank: 1,
+                    placeId: 201,
+                    name: "강남브런치",
+                    categoryLabel: .cafe,
+                    address: "서울 강남구 테헤란로 1",
+                    score: 4.3,
+                    nearestStationId: 2,
+                    latitude: 37.4979,
+                    longitude: 127.0276
+                )
+            ]
+        ),
+        StationRecommendation(
+            station: MidpointStation(
+                stationId: 3,
+                rank: 3,
+                stationName: "선릉",
+                lines: "2호선·수인분당선",
+                distanceKm: 1.1,
+                latitude: 37.5045,
+                longitude: 127.0492
+            ),
+            places: [
+                RecommendedPlace(
+                    rank: 1,
+                    placeId: 301,
+                    name: "선릉포차",
+                    categoryLabel: .bar,
+                    address: "서울 강남구 선릉로 1",
+                    score: 4.0,
+                    nearestStationId: 3,
+                    latitude: 37.5045,
+                    longitude: 127.0492
+                )
+            ]
+        )
+    ]
+}

--- a/Projects/Presentation/HomeFeature/Sources/PickPlace/PickPlaceView.swift
+++ b/Projects/Presentation/HomeFeature/Sources/PickPlace/PickPlaceView.swift
@@ -8,6 +8,7 @@ import SwiftUI
 import ComposableArchitecture
 
 import DesignSystem
+import Entity
 
 /// 장소 투표 후보 담기 화면.
 /// GroupDetail과 동일하게 NavigationPage + Tab + TabContent로 구성한다.
@@ -76,6 +77,8 @@ private struct PickPlaceViewPreview: View {
     ) {
         var state = PickPlaceFeature.State(pickedPlaces: pickedPlaces, isHost: isHost)
         state.selectedSubTabIndex = selectedSubTabIndex
+        state.recommendedPlaceMap.stationRecommendations = StationRecommendation.mock
+        state.recommendedPlaceMap.nearbyPlaceList.stationGroups = StationRecommendation.mock
         self.store = Store(initialState: state) {
             PickPlaceFeature()
         }

--- a/Projects/Presentation/HomeFeature/Sources/PickPlace/Tabs/PickedPlaceTab.swift
+++ b/Projects/Presentation/HomeFeature/Sources/PickPlace/Tabs/PickedPlaceTab.swift
@@ -54,10 +54,14 @@ struct PickedPlaceTab: View {
 private struct MemberStrip: View {
     let members: [PickPlaceMember]
 
+    private var sortedMembers: [PickPlaceMember] {
+        members.filter(\.isMe) + members.filter { !$0.isMe }
+    }
+
     var body: some View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack(spacing: Spacing.spacing300) {
-                ForEach(members) { member in
+                ForEach(sortedMembers) { member in
                     MemberItem(member: member)
                 }
             }
@@ -78,15 +82,31 @@ private struct MemberItem: View {
         return .image(url)
     }
 
+    private var label: String {
+        member.isMe ? "\(member.nickname)(나)" : member.nickname
+    }
+
     var body: some View {
-        VStack(spacing: Spacing.spacing150) {
+        VStack(spacing: Spacing.spacing350) {
             Avatar(avatarType: avatarType, size: .s56)
+                .overlay {
+                    Circle()
+                        .stroke(Color(hex: Constant.avatarBorderHex), lineWidth: Metric.avatarBorderWidth)
+                }
                 .opacity(member.hasPicked ? 1 : Opacity.opacity400)
 
-            BangawoText(member.nickname, textStyle: .bodySmall)
-                .foregroundStyle(member.hasPicked ? Colors.gray800 : Colors.gray500)
+            BangawoText(label, textStyle: .bodySmall)
+                .foregroundStyle(Colors.gray800)
         }
     }
+}
+
+private enum Metric {
+    static let avatarBorderWidth: CGFloat = 1.78
+}
+
+private enum Constant {
+    static let avatarBorderHex = "D8D8D8"
 }
 
 // MARK: - 카테고리 필터 칩

--- a/Projects/Presentation/HomeFeature/Sources/PickPlace/Tabs/PickedPlaceTab.swift
+++ b/Projects/Presentation/HomeFeature/Sources/PickPlace/Tabs/PickedPlaceTab.swift
@@ -18,24 +18,30 @@ struct PickedPlaceTab: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            ScrollView {
+            if store.isPickedPlaceEmpty {
                 VStack(spacing: 0) {
                     MemberStrip(members: store.members)
-                        .padding(.vertical, Spacing.spacing300)
+                        .padding(.top, Spacing.spacing300)
 
-                    if store.isPickedPlaceEmpty {
-                        PickedPlaceEmptyView {
-                            store.send(.goPickPlaceTapped)
-                        }
-                    } else {
-                        CategoryFilterStrip(
+                    PickedPlaceEmptyView {
+                        store.send(.goPickPlaceTapped)
+                    }
+                    .padding(.top, Spacing.spacing500)
+                    .frame(maxHeight: .infinity)
+                }
+            } else {
+                ScrollView {
+                    VStack(spacing: 0) {
+                        MemberStrip(members: store.members)
+                            .padding(.top, Spacing.spacing300)
+
+                        PickedPlaceContent(
                             filters: store.categoryFilters,
                             selectedCategory: store.selectedFilterCategory,
+                            places: store.filteredPickedPlaces,
                             onSelect: { store.send(.categoryFilterSelected($0)) }
                         )
-                        .padding(.bottom, Spacing.spacing200)
-
-                        PickedPlaceList(places: store.filteredPickedPlaces)
+                        .padding(.top, Spacing.spacing500)
                     }
                 }
             }
@@ -83,7 +89,7 @@ private struct MemberItem: View {
     }
 
     private var label: String {
-        member.isMe ? "\(member.nickname)(나)" : member.nickname
+        member.isMe ? "\(member.nickname) (나)" : member.nickname
     }
 
     var body: some View {
@@ -93,7 +99,6 @@ private struct MemberItem: View {
                     Circle()
                         .stroke(Color(hex: Constant.avatarBorderHex), lineWidth: Metric.avatarBorderWidth)
                 }
-                .opacity(member.hasPicked ? 1 : Opacity.opacity400)
 
             BangawoText(label, textStyle: .bodySmall)
                 .foregroundStyle(Colors.gray800)
@@ -103,6 +108,8 @@ private struct MemberItem: View {
 
 private enum Metric {
     static let avatarBorderWidth: CGFloat = 1.78
+    static let categoryFilterGap: CGFloat = 17
+    static let filterToListSpacing: CGFloat = 21
 }
 
 private enum Constant {
@@ -118,7 +125,7 @@ private struct CategoryFilterStrip: View {
 
     var body: some View {
         ScrollView(.horizontal, showsIndicators: false) {
-            HStack(spacing: Spacing.spacing200) {
+            HStack(spacing: Metric.categoryFilterGap) {
                 ForEach(filters) { filter in
                     CategoryFilterChip(
                         label: filter.label,
@@ -139,16 +146,38 @@ private struct CategoryFilterChip: View {
 
     var body: some View {
         Button(action: onTap) {
-            BangawoText(label, textStyle: .labelSmall)
-                .foregroundStyle(isSelected ? Colors.gray00 : Colors.gray700)
+            BangawoText(label, textStyle: .titleSmall)
+                .foregroundStyle(isSelected ? Colors.gray800 : Colors.gray700)
+                .padding(.vertical, Spacing.spacing200)
                 .padding(.horizontal, Spacing.spacing250)
-                .padding(.vertical, Spacing.spacing150)
                 .background(
-                    RoundedRectangle(cornerRadius: BorderRadius.borderRadiusFull)
-                        .fill(isSelected ? Colors.gray900 : Colors.gray100)
+                    Capsule()
+                        .fill(isSelected ? Colors.grayAlpha200 : Color.clear)
                 )
         }
         .buttonStyle(.plain)
+    }
+}
+
+// MARK: - 담은 장소 컨텐츠 (카테고리 필터 + 리스트)
+
+private struct PickedPlaceContent: View {
+    let filters: [PickedPlaceTabFeature.CategoryFilter]
+    let selectedCategory: PlaceCategory
+    let places: [PickedPlace]
+    let onSelect: (PlaceCategory) -> Void
+
+    var body: some View {
+        VStack(spacing: 0) {
+            CategoryFilterStrip(
+                filters: filters,
+                selectedCategory: selectedCategory,
+                onSelect: onSelect
+            )
+            .padding(.bottom, Metric.filterToListSpacing)
+
+            PickedPlaceList(places: places)
+        }
     }
 }
 
@@ -166,8 +195,14 @@ private struct PickedPlaceList: View {
                     displayAddress: place.address
                 ) {
                     if place.pickedCount > 1 {
-                        BangawoText("\(place.pickedCount)명 선택", textStyle: .labelSmallEmphasized)
-                            .foregroundStyle(Colors.gray700)
+                        BangawoText("\(place.pickedCount)명 선택", textStyle: .labelXSmall)
+                            .foregroundStyle(Colors.gray00)
+                            .padding(.vertical, Spacing.spacing100)
+                            .padding(.horizontal, Spacing.spacing150)
+                            .background(
+                                RoundedRectangle(cornerRadius: BorderRadius.borderRadius150)
+                                    .fill(Colors.orange600)
+                            )
                     }
                 }
             }
@@ -181,14 +216,20 @@ private struct PickedPlaceEmptyView: View {
     let onTap: () -> Void
 
     var body: some View {
-        VStack(spacing: Spacing.spacing300) {
-            BangawoText("아직 담은 장소가 없어요", textStyle: .bodyMedium)
-                .foregroundStyle(Colors.gray600)
+        VStack(spacing: 0) {
+            BangawoText("어느 장소가 가장 마음에 드시나요?", textStyle: .titleSmallEmphasized)
+                .foregroundStyle(Colors.gray700)
+                .multilineTextAlignment(.center)
 
-            BangawoButton("투표 후보 담으러가기", variant: .weak, size: .medium, action: onTap)
+            BangawoText("추천 장소들을 둘러보고\n다 함께 투표할 후보를 골라주세요!", textStyle: .titleSmall)
+                .foregroundStyle(Colors.gray700)
+                .multilineTextAlignment(.center)
+                .padding(.top, Spacing.spacing225)
+
+            BangawoButton("투표 후보 담으러가기", variant: .solid, size: .small, action: onTap)
+                .padding(.top, Spacing.spacing500)
         }
-        .frame(maxWidth: .infinity)
-        .padding(.top, Spacing.spacing700)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
         .padding(.horizontal, Spacing.spacing400)
     }
 }

--- a/Projects/Presentation/HomeFeature/Sources/PickPlace/Tabs/RecommendedPlaceMapTab.swift
+++ b/Projects/Presentation/HomeFeature/Sources/PickPlace/Tabs/RecommendedPlaceMapTab.swift
@@ -87,3 +87,52 @@ private enum Constant {
     /// 좌표 정보가 없을 때 사용하는 기본 지도 중심(서울 시청).
     static let defaultCenter = MapCoordinate(latitude: 37.5665, longitude: 126.9780)
 }
+
+// MARK: - Preview
+
+#if DEBUG
+private struct RecommendedPlaceMapTabPreview: View {
+    private let store: StoreOf<RecommendedPlaceMapTabFeature>
+
+    init(stationRecommendations: [StationRecommendation]) {
+        var state = RecommendedPlaceMapTabFeature.State()
+        state.stationRecommendations = stationRecommendations
+        state.nearbyPlaceList.stationGroups = stationRecommendations
+        self.store = Store(initialState: state) {
+            RecommendedPlaceMapTabFeature()
+        }
+    }
+
+    var body: some View {
+        RecommendedPlaceMapTab(store: store)
+    }
+}
+
+private enum PreviewData {
+    private enum Constant {
+        static let stationCount = 3
+    }
+
+    static let stationRecommendations: [StationRecommendation] = {
+        let recommendations = Array(StationRecommendation.mock.prefix(Constant.stationCount))
+        assert(recommendations.count == Constant.stationCount)
+        return recommendations
+    }()
+
+    static let emptyPlaceStationRecommendations = stationRecommendations.map {
+        StationRecommendation(station: $0.station, places: [])
+    }
+}
+
+#Preview("추천 장소 있음") {
+    BangawoPreview {
+        RecommendedPlaceMapTabPreview(stationRecommendations: PreviewData.stationRecommendations)
+    }
+}
+
+#Preview("추천 장소 없음") {
+    BangawoPreview {
+        RecommendedPlaceMapTabPreview(stationRecommendations: PreviewData.emptyPlaceStationRecommendations)
+    }
+}
+#endif

--- a/Projects/Shared/DesignSystem/Sources/Components/ToggleButton/ToggleButton.swift
+++ b/Projects/Shared/DesignSystem/Sources/Components/ToggleButton/ToggleButton.swift
@@ -1,0 +1,59 @@
+//
+//  ToggleButton.swift
+//  DesignSystem
+//
+
+import SwiftUI
+
+public struct ToggleButton: View {
+    // MARK: - Properties
+
+    private let isSelected: Bool
+    private let action: () -> Void
+
+    // MARK: - Init
+
+    public init(isSelected: Bool, action: @escaping () -> Void) {
+        self.isSelected = isSelected
+        self.action = action
+    }
+
+    // MARK: - Body
+
+    public var body: some View {
+        Button(action: action) {
+            Image.Asset.icPlus16
+                .renderingMode(.template)
+                .resizable()
+                .scaledToFit()
+                .frame(width: Sizing.sizing100, height: Sizing.sizing100)
+                .foregroundStyle(isSelected ? Colors.white : Colors.gray600)
+                .padding(Spacing.spacing200)
+                .background {
+                    Circle()
+                        .fill(isSelected ? Colors.gray800 : Color.clear)
+                        .overlay {
+                            if !isSelected {
+                                Circle()
+                                    .stroke(Colors.gray300, lineWidth: BorderWidth.borderWidth100)
+                            }
+                        }
+                }
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+// MARK: - Preview
+
+#Preview("ToggleButton") {
+    ZStack {
+        Colors.gray200
+            .ignoresSafeArea()
+
+        HStack(spacing: Spacing.spacing300) {
+            ToggleButton(isSelected: false) {}
+            ToggleButton(isSelected: true) {}
+        }
+    }
+}


### PR DESCRIPTION
## 📌 PR Summary

추천장소 담기와 장소 투표 화면을 이슈 #85의 최신 디자인 명세에 맞춰 정리했습니다.

Closes #85

## ✨ 주요변경사항

- 추천 장소 지도 탭의 역 선택 컨트롤을 `ToggleButton` 기반 segmented UI로 정리
- 담은 장소 탭의 멤버 스트립, 장소 행, 선택 인원 표시, 빈 상태 레이아웃을 디자인 토큰 기준으로 조정
- 장소 투표 참여 시트의 헤더, 후보 리스트, 참여 인원 버튼, 1위/투표 수 표시를 명세에 맞게 정리
- 장소 투표 참여자 화면의 헤더, 리스트 패딩, 프로필, 본인 칩, 투표 상태 배지를 정리
- 장소 담기 상태 모델에 본인 여부/프로필 표시용 값을 반영
- 추천 장소 지도 탭과 장소 투표 참여자 화면 프리뷰를 추가

## 🧩 구조

- `ToggleButton` 컴포넌트를 추가해 근처 장소 역 선택 UI에서 재사용하도록 구성했습니다.
- `PlaceVoteSheetContent`의 후보 리스트를 `PlaceVoteList` 서브뷰로 분리해 헤더와 리스트 padding 책임을 분리했습니다.
- `PlaceVoteParticipantsView`는 Header/ListHeader/ProfileAsset/Badge 계열 서브뷰로 나눠 화면 구조를 명확히 했습니다.
- `PlacePickStatus`와 DTO 변환에 프로필/본인 여부 표시 데이터를 연결했습니다.

## ✅ 검증

- [x] `git diff --check develop..HEAD`
- [ ] `xcodebuild -workspace Bangawo.xcworkspace -scheme HomeFeature -destination 'platform=iOS Simulator,name=iPhone 17' build CODE_SIGNING_ALLOWED=NO`
  - 현재 로컬 환경에서 `Bangawo.xcworkspace is not a workspace file` 및 CoreSimulator 접근 오류로 빌드 실행 전 단계에서 실패했습니다.
