### PR TITLE
[FEAT] 근처 역·장소 조회 및 장소 상세 조회 구현

### DIFF
--- a/Projects/App/Sources/Application/BangawoApp.swift
+++ b/Projects/App/Sources/Application/BangawoApp.swift
@@ -32,6 +32,7 @@ struct BangawoApp: App {
             $0.themeTagClient = ThemeTagFactory.makeClient()
             $0.departurePlaceClient = DeparturePlaceFactory.makeClient()
             $0.nearbyPlacesClient = NearbyPlacesFactory.makeClient()
+            $0.placeDetailsClient = PlaceDetailsFactory.makeClient()
         }
 
         store = Store(initialState: RootFeature.State()) {

--- a/Projects/App/Sources/Application/BangawoApp.swift
+++ b/Projects/App/Sources/Application/BangawoApp.swift
@@ -31,6 +31,7 @@ struct BangawoApp: App {
             $0.placePickClient = PlacePickFactory.makeClient()
             $0.themeTagClient = ThemeTagFactory.makeClient()
             $0.departurePlaceClient = DeparturePlaceFactory.makeClient()
+            $0.nearbyPlacesClient = NearbyPlacesFactory.makeClient()
         }
 
         store = Store(initialState: RootFeature.State()) {

--- a/Projects/App/Sources/Factory/NearbyPlacesFactory.swift
+++ b/Projects/App/Sources/Factory/NearbyPlacesFactory.swift
@@ -1,0 +1,18 @@
+//
+//  NearbyPlacesFactory.swift
+//  App
+//
+//  Repository → UseCase → TCA Client을 조립하는 Composition Root
+//
+
+import CoreDependencies
+import DataUseCase
+import Repository
+
+enum NearbyPlacesFactory {
+    static func makeClient() -> NearbyPlacesClient {
+        let repository = NearbyPlacesRepositoryImpl()
+        let useCase = FetchNearbyPlacesUseCaseImpl(repository: repository)
+        return .live(useCase: useCase)
+    }
+}

--- a/Projects/App/Sources/Factory/PlaceDetailsFactory.swift
+++ b/Projects/App/Sources/Factory/PlaceDetailsFactory.swift
@@ -1,0 +1,18 @@
+//
+//  PlaceDetailsFactory.swift
+//  App
+//
+//  Repository → UseCase → TCA Client을 조립하는 Composition Root
+//
+
+import CoreDependencies
+import DataUseCase
+import Repository
+
+enum PlaceDetailsFactory {
+    static func makeClient() -> PlaceDetailsClient {
+        let repository = PlaceDetailsRepositoryImpl()
+        let useCase = FetchPlaceDetailsUseCaseImpl(repository: repository)
+        return .live(useCase: useCase)
+    }
+}

--- a/Projects/Core/CoreDependencies/Sources/NearbyPlacesClient.swift
+++ b/Projects/Core/CoreDependencies/Sources/NearbyPlacesClient.swift
@@ -1,0 +1,68 @@
+//
+//  NearbyPlacesClient.swift
+//  CoreDependencies
+//
+//  역 기반 근처 장소 조회를 Feature에 노출하는 TCA struct-based client
+//
+
+import Foundation
+
+import ComposableArchitecture
+
+import Entity
+import UseCase
+
+@DependencyClient
+public struct NearbyPlacesClient: Sendable {
+    public var fetchNearbyPlaces: @Sendable (
+        _ latitude: Double,
+        _ longitude: Double,
+        _ radiusMeters: Double,
+        _ category: String?
+    ) async throws -> [NearbyPlace]
+}
+
+public extension NearbyPlacesClient {
+    static func live(useCase: FetchNearbyPlacesUseCase) -> Self {
+        Self(
+            fetchNearbyPlaces: { latitude, longitude, radiusMeters, category in
+                try await useCase.execute(
+                    latitude: latitude,
+                    longitude: longitude,
+                    radiusMeters: radiusMeters,
+                    category: category
+                )
+            }
+        )
+    }
+}
+
+extension NearbyPlacesClient: DependencyKey {
+    public static var liveValue: NearbyPlacesClient {
+        NearbyPlacesClient(
+            fetchNearbyPlaces: { _, _, _, _ in throw NearbyPlacesClientError.notImplemented }
+        )
+    }
+
+    public static let testValue: NearbyPlacesClient = NearbyPlacesClient()
+}
+
+public extension DependencyValues {
+    var nearbyPlacesClient: NearbyPlacesClient {
+        get { self[NearbyPlacesClient.self] }
+        set { self[NearbyPlacesClient.self] = newValue }
+    }
+}
+
+/// NearbyPlacesClient에서 Presentation 계층이 이해할 수 있는 공통 에러 타입입니다.
+public enum NearbyPlacesClientError: LocalizedError, Equatable, Sendable {
+    /// 아직 live 구현이 주입되지 않은 Client를 호출했을 때 사용하는 임시 에러입니다.
+    case notImplemented
+
+    public var errorDescription: String? {
+        switch self {
+        case .notImplemented:
+            return "NearbyPlacesClient의 live 구현이 주입되지 않았습니다."
+        }
+    }
+}

--- a/Projects/Core/CoreDependencies/Sources/PlaceDetailsClient.swift
+++ b/Projects/Core/CoreDependencies/Sources/PlaceDetailsClient.swift
@@ -1,0 +1,58 @@
+//
+//  PlaceDetailsClient.swift
+//  CoreDependencies
+//
+//  placeId 기반 장소 상세 조회를 Feature에 노출하는 TCA struct-based client
+//
+
+import Foundation
+
+import ComposableArchitecture
+
+import Entity
+import UseCase
+
+@DependencyClient
+public struct PlaceDetailsClient: Sendable {
+    public var fetchPlaceDetails: @Sendable (_ ids: [Int]) async throws -> [PlaceDetail]
+}
+
+public extension PlaceDetailsClient {
+    static func live(useCase: FetchPlaceDetailsUseCase) -> Self {
+        Self(
+            fetchPlaceDetails: { ids in
+                try await useCase.execute(ids: ids)
+            }
+        )
+    }
+}
+
+extension PlaceDetailsClient: DependencyKey {
+    public static var liveValue: PlaceDetailsClient {
+        PlaceDetailsClient(
+            fetchPlaceDetails: { _ in throw PlaceDetailsClientError.notImplemented }
+        )
+    }
+
+    public static let testValue: PlaceDetailsClient = PlaceDetailsClient()
+}
+
+public extension DependencyValues {
+    var placeDetailsClient: PlaceDetailsClient {
+        get { self[PlaceDetailsClient.self] }
+        set { self[PlaceDetailsClient.self] = newValue }
+    }
+}
+
+/// PlaceDetailsClient에서 Presentation 계층이 이해할 수 있는 공통 에러 타입입니다.
+public enum PlaceDetailsClientError: LocalizedError, Equatable, Sendable {
+    /// 아직 live 구현이 주입되지 않은 Client를 호출했을 때 사용하는 임시 에러입니다.
+    case notImplemented
+
+    public var errorDescription: String? {
+        switch self {
+        case .notImplemented:
+            return "PlaceDetailsClient의 live 구현이 주입되지 않았습니다."
+        }
+    }
+}

--- a/Projects/Data/API/Sources/PlacesEndpoint.swift
+++ b/Projects/Data/API/Sources/PlacesEndpoint.swift
@@ -1,0 +1,32 @@
+//
+//  PlacesEndpoint.swift
+//  API
+//
+
+import Foundation
+
+import Alamofire
+
+import Foundations
+
+public enum PlacesEndpoint {
+    case fetchDetails(ids: [Int])
+}
+
+extension PlacesEndpoint: EndPoint {
+    public var baseURL: String { APIConfiguration.serverBaseURL }
+
+    public var path: String { "/api/v1/places" }
+
+    public var method: HTTPMethod { .get }
+
+    public var task: APITask {
+        switch self {
+        case let .fetchDetails(ids):
+            return .requestParametersWithEncoding(
+                parameters: ["ids": ids],
+                encoding: URLEncoding(arrayEncoding: .noBrackets)
+            )
+        }
+    }
+}

--- a/Projects/Data/API/Sources/PlacesNearbyEndpoint.swift
+++ b/Projects/Data/API/Sources/PlacesNearbyEndpoint.swift
@@ -1,0 +1,39 @@
+//
+//  PlacesNearbyEndpoint.swift
+//  API
+//
+
+import Foundation
+
+import Alamofire
+
+import Foundations
+
+public enum PlacesNearbyEndpoint {
+    case fetch(latitude: Double, longitude: Double, radiusMeters: Double, category: String?)
+}
+
+extension PlacesNearbyEndpoint: EndPoint {
+    public var baseURL: String { APIConfiguration.serverBaseURL }
+
+    public var path: String { "/api/v1/places/nearby" }
+
+    public var method: HTTPMethod { .get }
+
+    public var task: APITask {
+        switch self {
+        case let .fetch(latitude, longitude, radiusMeters, category):
+            var parameters: Parameters = [
+                "latitude": latitude,
+                "longitude": longitude,
+                "radiusMeters": radiusMeters
+            ]
+
+            if let category {
+                parameters["category"] = category
+            }
+
+            return .requestParameters(parameters: parameters)
+        }
+    }
+}

--- a/Projects/Data/DataUseCase/Sources/FetchNearbyPlacesUseCaseImpl.swift
+++ b/Projects/Data/DataUseCase/Sources/FetchNearbyPlacesUseCaseImpl.swift
@@ -1,0 +1,30 @@
+//
+//  FetchNearbyPlacesUseCaseImpl.swift
+//  DataUseCase
+//
+
+import DataInterface
+import Entity
+import UseCase
+
+public final class FetchNearbyPlacesUseCaseImpl: FetchNearbyPlacesUseCase {
+    private let repository: NearbyPlacesRepositoryProtocol
+
+    public init(repository: NearbyPlacesRepositoryProtocol) {
+        self.repository = repository
+    }
+
+    public func execute(
+        latitude: Double,
+        longitude: Double,
+        radiusMeters: Double,
+        category: String?
+    ) async throws -> [NearbyPlace] {
+        try await repository.fetchNearbyPlaces(
+            latitude: latitude,
+            longitude: longitude,
+            radiusMeters: radiusMeters,
+            category: category
+        )
+    }
+}

--- a/Projects/Data/DataUseCase/Sources/FetchPlaceDetailsUseCaseImpl.swift
+++ b/Projects/Data/DataUseCase/Sources/FetchPlaceDetailsUseCaseImpl.swift
@@ -1,0 +1,20 @@
+//
+//  FetchPlaceDetailsUseCaseImpl.swift
+//  DataUseCase
+//
+
+import DataInterface
+import Entity
+import UseCase
+
+public final class FetchPlaceDetailsUseCaseImpl: FetchPlaceDetailsUseCase {
+    private let repository: PlaceDetailsRepositoryProtocol
+
+    public init(repository: PlaceDetailsRepositoryProtocol) {
+        self.repository = repository
+    }
+
+    public func execute(ids: [Int]) async throws -> [PlaceDetail] {
+        try await repository.fetchPlaceDetails(ids: ids)
+    }
+}

--- a/Projects/Data/Model/Sources/NearbyPlaceResponseDTO.swift
+++ b/Projects/Data/Model/Sources/NearbyPlaceResponseDTO.swift
@@ -1,0 +1,40 @@
+//
+//  NearbyPlaceResponseDTO.swift
+//  Model
+//
+
+import Entity
+
+public struct NearbyPlaceResponseDTO: Decodable, Sendable {
+    public let placeId: Int
+    public let name: String
+    public let categoryLabel: String
+    public let address: String
+    public let latitude: Double
+    public let longitude: Double
+    public let vibe: [String]
+    public let occasion: [String]
+    public let reservable: Bool
+    public let hasParking: Bool
+    public let rating: Double
+    public let distanceMeters: Double
+}
+
+public extension NearbyPlaceResponseDTO {
+    func toEntity() -> NearbyPlace {
+        NearbyPlace(
+            placeId: placeId,
+            name: name,
+            categoryLabel: PlaceCategory(categoryLabel: categoryLabel),
+            address: address,
+            latitude: latitude,
+            longitude: longitude,
+            vibe: vibe,
+            occasion: occasion,
+            reservable: reservable,
+            hasParking: hasParking,
+            rating: rating,
+            distanceMeters: distanceMeters
+        )
+    }
+}

--- a/Projects/Data/Model/Sources/PlaceDetailResponseDTO.swift
+++ b/Projects/Data/Model/Sources/PlaceDetailResponseDTO.swift
@@ -1,0 +1,46 @@
+//
+//  PlaceDetailResponseDTO.swift
+//  Model
+//
+
+import Entity
+
+public struct PlaceDetailResponseDTO: Decodable, Sendable {
+    public let placeId: Int
+    public let name: String
+    public let categoryLabel: String
+    public let address: String
+    public let roadAddress: String
+    public let latitude: Double
+    public let longitude: Double
+    public let vibe: [String]
+    public let occasion: [String]
+    public let reservable: Bool
+    public let hasParking: Bool
+    public let rating: Double
+    public let businessHours: String
+    public let holiday: String
+    public let naverUrl: String
+}
+
+public extension PlaceDetailResponseDTO {
+    func toEntity() -> PlaceDetail {
+        PlaceDetail(
+            placeId: placeId,
+            name: name,
+            categoryLabel: PlaceCategory(categoryLabel: categoryLabel),
+            address: address,
+            roadAddress: roadAddress,
+            latitude: latitude,
+            longitude: longitude,
+            vibe: vibe,
+            occasion: occasion,
+            reservable: reservable,
+            hasParking: hasParking,
+            rating: rating,
+            businessHours: businessHours,
+            holiday: holiday,
+            naverUrl: naverUrl
+        )
+    }
+}

--- a/Projects/Data/Model/Sources/RecommendedPlaceDTO.swift
+++ b/Projects/Data/Model/Sources/RecommendedPlaceDTO.swift
@@ -18,6 +18,9 @@ public struct RecommendedPlaceResponseDTO: Decodable, Sendable {
         public let address: String
         public let latitude: Double
         public let longitude: Double
+        // TODO: 백엔드 추천 응답에 주차/예약 필드 추가 시 optional 제거
+        public let hasParking: Bool?
+        public let reservable: Bool?
     }
 }
 
@@ -32,7 +35,9 @@ public extension RecommendedPlaceResponseDTO {
             score: score,
             nearestStationId: nearestStationId,
             latitude: place.latitude,
-            longitude: place.longitude
+            longitude: place.longitude,
+            hasParking: place.hasParking,
+            reservable: place.reservable
         )
     }
 }

--- a/Projects/Data/Repository/Sources/NearbyPlacesRepositoryImpl.swift
+++ b/Projects/Data/Repository/Sources/NearbyPlacesRepositoryImpl.swift
@@ -1,0 +1,32 @@
+//
+//  NearbyPlacesRepositoryImpl.swift
+//  Repository
+//
+
+import API
+import DataInterface
+import Entity
+import Model
+import Networking
+
+public final class NearbyPlacesRepositoryImpl: NearbyPlacesRepositoryProtocol {
+    public init() {}
+
+    public func fetchNearbyPlaces(
+        latitude: Double,
+        longitude: Double,
+        radiusMeters: Double,
+        category: String?
+    ) async throws -> [NearbyPlace] {
+        let response: [NearbyPlaceResponseDTO] = try await NetworkManager.shared.request(
+            PlacesNearbyEndpoint.fetch(
+                latitude: latitude,
+                longitude: longitude,
+                radiusMeters: radiusMeters,
+                category: category
+            )
+        )
+
+        return response.map { $0.toEntity() }
+    }
+}

--- a/Projects/Data/Repository/Sources/PlaceDetailsRepositoryImpl.swift
+++ b/Projects/Data/Repository/Sources/PlaceDetailsRepositoryImpl.swift
@@ -1,0 +1,22 @@
+//
+//  PlaceDetailsRepositoryImpl.swift
+//  Repository
+//
+
+import API
+import DataInterface
+import Entity
+import Model
+import Networking
+
+public final class PlaceDetailsRepositoryImpl: PlaceDetailsRepositoryProtocol {
+    public init() {}
+
+    public func fetchPlaceDetails(ids: [Int]) async throws -> [PlaceDetail] {
+        let response: [PlaceDetailResponseDTO] = try await NetworkManager.shared.request(
+            PlacesEndpoint.fetchDetails(ids: ids)
+        )
+
+        return response.map { $0.toEntity() }
+    }
+}

--- a/Projects/Domain/DataInterface/Sources/NearbyPlacesRepositoryProtocol.swift
+++ b/Projects/Domain/DataInterface/Sources/NearbyPlacesRepositoryProtocol.swift
@@ -1,0 +1,15 @@
+//
+//  NearbyPlacesRepositoryProtocol.swift
+//  DataInterface
+//
+
+import Entity
+
+public protocol NearbyPlacesRepositoryProtocol: Sendable {
+    func fetchNearbyPlaces(
+        latitude: Double,
+        longitude: Double,
+        radiusMeters: Double,
+        category: String?
+    ) async throws -> [NearbyPlace]
+}

--- a/Projects/Domain/DataInterface/Sources/PlaceDetailsRepositoryProtocol.swift
+++ b/Projects/Domain/DataInterface/Sources/PlaceDetailsRepositoryProtocol.swift
@@ -1,0 +1,10 @@
+//
+//  PlaceDetailsRepositoryProtocol.swift
+//  DataInterface
+//
+
+import Entity
+
+public protocol PlaceDetailsRepositoryProtocol: Sendable {
+    func fetchPlaceDetails(ids: [Int]) async throws -> [PlaceDetail]
+}

--- a/Projects/Domain/Entity/Sources/Place/NearbyPlace.swift
+++ b/Projects/Domain/Entity/Sources/Place/NearbyPlace.swift
@@ -1,0 +1,51 @@
+//
+//  NearbyPlace.swift
+//  Entity
+//
+
+import Foundation
+
+public struct NearbyPlace: Equatable, Sendable, Identifiable {
+    public let placeId: Int
+    public let name: String
+    public let categoryLabel: PlaceCategory
+    public let address: String
+    public let latitude: Double
+    public let longitude: Double
+    public let vibe: [String]
+    public let occasion: [String]
+    public let reservable: Bool
+    public let hasParking: Bool
+    public let rating: Double
+    public let distanceMeters: Double
+
+    public var id: Int { placeId }
+
+    public init(
+        placeId: Int,
+        name: String,
+        categoryLabel: PlaceCategory,
+        address: String,
+        latitude: Double,
+        longitude: Double,
+        vibe: [String],
+        occasion: [String],
+        reservable: Bool,
+        hasParking: Bool,
+        rating: Double,
+        distanceMeters: Double
+    ) {
+        self.placeId = placeId
+        self.name = name
+        self.categoryLabel = categoryLabel
+        self.address = address
+        self.latitude = latitude
+        self.longitude = longitude
+        self.vibe = vibe
+        self.occasion = occasion
+        self.reservable = reservable
+        self.hasParking = hasParking
+        self.rating = rating
+        self.distanceMeters = distanceMeters
+    }
+}

--- a/Projects/Domain/Entity/Sources/Place/PlaceDetail.swift
+++ b/Projects/Domain/Entity/Sources/Place/PlaceDetail.swift
@@ -1,0 +1,60 @@
+//
+//  PlaceDetail.swift
+//  Entity
+//
+
+import Foundation
+
+public struct PlaceDetail: Equatable, Sendable, Identifiable {
+    public let placeId: Int
+    public let name: String
+    public let categoryLabel: PlaceCategory
+    public let address: String
+    public let roadAddress: String
+    public let latitude: Double
+    public let longitude: Double
+    public let vibe: [String]
+    public let occasion: [String]
+    public let reservable: Bool
+    public let hasParking: Bool
+    public let rating: Double
+    public let businessHours: String
+    public let holiday: String
+    public let naverUrl: String
+
+    public var id: Int { placeId }
+
+    public init(
+        placeId: Int,
+        name: String,
+        categoryLabel: PlaceCategory,
+        address: String,
+        roadAddress: String,
+        latitude: Double,
+        longitude: Double,
+        vibe: [String],
+        occasion: [String],
+        reservable: Bool,
+        hasParking: Bool,
+        rating: Double,
+        businessHours: String,
+        holiday: String,
+        naverUrl: String
+    ) {
+        self.placeId = placeId
+        self.name = name
+        self.categoryLabel = categoryLabel
+        self.address = address
+        self.roadAddress = roadAddress
+        self.latitude = latitude
+        self.longitude = longitude
+        self.vibe = vibe
+        self.occasion = occasion
+        self.reservable = reservable
+        self.hasParking = hasParking
+        self.rating = rating
+        self.businessHours = businessHours
+        self.holiday = holiday
+        self.naverUrl = naverUrl
+    }
+}

--- a/Projects/Domain/Entity/Sources/PlaceRecommendation/RecommendedPlace.swift
+++ b/Projects/Domain/Entity/Sources/PlaceRecommendation/RecommendedPlace.swift
@@ -15,6 +15,9 @@ public struct RecommendedPlace: Equatable, Sendable, Identifiable {
     public let nearestStationId: Int
     public let latitude: Double
     public let longitude: Double
+    // TODO: 백엔드 추천 응답에 주차/예약 필드 추가 시 non-optional 로 변경
+    public let hasParking: Bool?
+    public let reservable: Bool?
 
     public var id: Int { placeId }
 
@@ -27,7 +30,9 @@ public struct RecommendedPlace: Equatable, Sendable, Identifiable {
         score: Double,
         nearestStationId: Int,
         latitude: Double,
-        longitude: Double
+        longitude: Double,
+        hasParking: Bool? = nil,
+        reservable: Bool? = nil
     ) {
         self.rank = rank
         self.placeId = placeId
@@ -38,5 +43,7 @@ public struct RecommendedPlace: Equatable, Sendable, Identifiable {
         self.nearestStationId = nearestStationId
         self.latitude = latitude
         self.longitude = longitude
+        self.hasParking = hasParking
+        self.reservable = reservable
     }
 }

--- a/Projects/Domain/UseCase/Sources/FetchNearbyPlacesUseCase.swift
+++ b/Projects/Domain/UseCase/Sources/FetchNearbyPlacesUseCase.swift
@@ -1,0 +1,15 @@
+//
+//  FetchNearbyPlacesUseCase.swift
+//  UseCase
+//
+
+import Entity
+
+public protocol FetchNearbyPlacesUseCase: Sendable {
+    func execute(
+        latitude: Double,
+        longitude: Double,
+        radiusMeters: Double,
+        category: String?
+    ) async throws -> [NearbyPlace]
+}

--- a/Projects/Domain/UseCase/Sources/FetchPlaceDetailsUseCase.swift
+++ b/Projects/Domain/UseCase/Sources/FetchPlaceDetailsUseCase.swift
@@ -1,0 +1,10 @@
+//
+//  FetchPlaceDetailsUseCase.swift
+//  UseCase
+//
+
+import Entity
+
+public protocol FetchPlaceDetailsUseCase: Sendable {
+    func execute(ids: [Int]) async throws -> [PlaceDetail]
+}

--- a/Projects/Network/Foundations/Sources/APITask.swift
+++ b/Projects/Network/Foundations/Sources/APITask.swift
@@ -17,6 +17,8 @@ public enum APITask {
     case requestJSONEncodable(body: Encodable & Sendable)
     /// URL 쿼리 파라미터로 전달
     case requestParameters(parameters: Parameters)
+    /// URL 쿼리 파라미터를 지정한 인코딩으로 전달 (배열 인코딩 방식 커스터마이즈용)
+    case requestParametersWithEncoding(parameters: Parameters, encoding: URLEncoding)
     /// 인터셉터 없는 요청
     case requestWithoutInterceptor(body: (Encodable & Sendable)? = nil)
     /// 인터셉터 없는 쿼리 파라미터 요청 (외부 API용)

--- a/Projects/Network/Networking/Sources/NetworkManager.swift
+++ b/Projects/Network/Networking/Sources/NetworkManager.swift
@@ -126,6 +126,15 @@ public final class NetworkManager: Sendable {
                 headers: endPoint.headers,
                 interceptor: Interceptor()
             ).validate()
+        case let .requestParametersWithEncoding(parameters, encoding):
+            return AF.request(
+                "\(endPoint.baseURL)\(endPoint.path)",
+                method: endPoint.method,
+                parameters: parameters,
+                encoding: encoding,
+                headers: endPoint.headers,
+                interceptor: Interceptor()
+            ).validate()
         case let .requestWithoutInterceptor(body):
             if let body = body {
                 return AF.request(

--- a/Projects/Presentation/HomeFeature/Sources/Common/PlaceRow.swift
+++ b/Projects/Presentation/HomeFeature/Sources/Common/PlaceRow.swift
@@ -24,6 +24,8 @@ struct PlaceRow<Trailing: View>: View {
     private let displayAddress: String
     private let tooltipAnimationDuration = 0.2
     private let trailing: Trailing
+    /// row 전체 영역 탭 핸들러. `nil`이면 row 자체는 탭에 반응하지 않는다.
+    private let onTap: (() -> Void)?
 
     /// 더미 데이터를 사용하는 기본 init. 서버 모델 확정 전 mock 용도.
     init(@ViewBuilder trailing: () -> Trailing = { EmptyView() }) {
@@ -40,20 +42,42 @@ struct PlaceRow<Trailing: View>: View {
         placeName: String,
         category: PlaceCategory?,
         displayAddress: String,
+        onTap: (() -> Void)? = nil,
         @ViewBuilder trailing: () -> Trailing = { EmptyView() }
     ) {
         self.placeName = placeName
         self.category = category
         self.displayAddress = displayAddress
+        self.onTap = onTap
         self.trailing = trailing()
     }
 
     /// `RecommendedPlace` 실데이터를 표시하는 init.
-    init(place: RecommendedPlace, @ViewBuilder trailing: () -> Trailing = { EmptyView() }) {
+    init(
+        place: RecommendedPlace,
+        onTap: (() -> Void)? = nil,
+        @ViewBuilder trailing: () -> Trailing = { EmptyView() }
+    ) {
         self.init(
             placeName: place.name,
             category: place.categoryLabel,
             displayAddress: place.address,
+            onTap: onTap,
+            trailing: trailing
+        )
+    }
+
+    /// `NearbyPlace` 실데이터를 표시하는 init.
+    init(
+        place: NearbyPlace,
+        onTap: (() -> Void)? = nil,
+        @ViewBuilder trailing: () -> Trailing = { EmptyView() }
+    ) {
+        self.init(
+            placeName: place.name,
+            category: place.categoryLabel,
+            displayAddress: place.address,
+            onTap: onTap,
             trailing: trailing
         )
     }
@@ -118,6 +142,24 @@ struct PlaceRow<Trailing: View>: View {
         .zIndex(isTooltipLayerElevated ? 1 : 0)
         .padding(.horizontal, Spacing.spacing400)
         .padding(.vertical, Spacing.spacing300)
+        // 내부 주소/trailing 버튼은 innermost 우선 디스패치로 유지되고, 빈 영역 탭만 onTap으로 전달됩니다.
+        .contentShape(Rectangle())
+        .modifier(RowTapModifier(onTap: onTap))
+    }
+}
+
+// MARK: - Row Tap
+
+/// `onTap`이 있을 때만 전체 row 탭 제스처를 붙입니다. `nil`이면 제스처를 달지 않아 기존 동작을 보존합니다.
+private struct RowTapModifier: ViewModifier {
+    let onTap: (() -> Void)?
+
+    func body(content: Content) -> some View {
+        if let onTap {
+            content.onTapGesture { onTap() }
+        } else {
+            content
+        }
     }
 }
 

--- a/Projects/Presentation/HomeFeature/Sources/GroupDetail/Tabs/MyPlaceTab/MyPlaceTab.swift
+++ b/Projects/Presentation/HomeFeature/Sources/GroupDetail/Tabs/MyPlaceTab/MyPlaceTab.swift
@@ -16,14 +16,26 @@ import Utill
 struct MyPlaceTab: View {
     let store: StoreOf<MyPlaceTabFeature>
 
-    // TODO: 디버깅용 임시 핀. 실제 장소 데이터 연동 시 제거한다.
+    /// 지도에 표시할 핀. 포커싱 장소 또는 역 기반 근처 장소 목록으로 구성한다.
     @State private var pins: [MapPin] = []
     /// 바텀시트가 화면 하단을 덮는 높이. detent에 따라 핀 포커싱 중심을 위로 보정하는 데 쓴다.
     @State private var sheetCoveredHeight: CGFloat = 0
 
+    /// 핀 재구성 트리거. 포커싱 장소 또는 근처 장소 목록이 바뀌면 핀을 다시 만든다.
+    private var pinInput: PinInput {
+        PinInput(focusedPlace: store.focusedPlace, nearbyPlaces: store.nearbyPlaceList.visibleNearbyPlaces)
+    }
+
     /// 포커싱 대상이 있으면 그 좌표, 없으면 기본 중심.
     private var mapCenter: MapCoordinate {
         guard let place = store.focusedPlace else { return Constant.defaultCenter }
+
+        return MapCoordinate(latitude: place.latitude, longitude: place.longitude)
+    }
+
+    /// 포커싱 장소가 있으면 그 좌표. 이미 살아있는 지도의 카메라를 애니메이션 이동시키는 데 쓴다.
+    private var focusedCoordinate: MapCoordinate? {
+        guard let place = store.focusedPlace else { return nil }
 
         return MapCoordinate(latitude: place.latitude, longitude: place.longitude)
     }
@@ -33,13 +45,16 @@ struct MyPlaceTab: View {
             KakaoMap(
                 pins: pins,
                 initialCenter: mapCenter,
+                focusedCoordinate: focusedCoordinate,
                 focusBottomInset: sheetCoveredHeight
             )
             .onPinTapped { pin in
                 Log.debug("핀 선택: id=\(pin.id), title=\(pin.title), coordinate=(\(pin.coordinate.latitude), \(pin.coordinate.longitude))")
             }
             .onCenterChanged { viewport in
-                Log.debug("중심 좌표 변경: center=(\(viewport.center.latitude), \(viewport.center.longitude)), zoomLevel=\(viewport.zoomLevel)")
+                store.send(.mapCenterChanged(
+                    MapCoordinate(latitude: viewport.center.latitude, longitude: viewport.center.longitude)
+                ))
             }
             .ignoresSafeArea()
             
@@ -59,20 +74,23 @@ struct MyPlaceTab: View {
             }
             .onVisibleHeightChanged { sheetCoveredHeight = $0 }
         }
-        .task(id: store.focusedPlace) {
+        .task(id: pinInput) {
             buildPins()
         }
     }
 
     // MARK: - Pin 구성
 
-    /// 포커싱 장소가 있으면 그 핀 하나만, 없으면 디버깅용 샘플 핀을 구성한다.
+    /// 포커싱 장소가 있으면 그 핀 하나만, 없으면 역 기반 근처 장소 핀을 구성한다.
     @MainActor
     private func buildPins() {
         guard let place = store.focusedPlace else {
-            pins = Constant.samplePlaces.map { place in
-                MapPinLabel(assetName: place.iconAsset, title: place.name)
-                    .makePin(id: place.name, coordinate: place.coordinate)
+            pins = store.nearbyPlaceList.visibleNearbyPlaces.map { place in
+                MapPinLabel(image: place.categoryLabel.pinIcon, title: place.name)
+                    .makePin(
+                        id: String(place.placeId),
+                        coordinate: MapCoordinate(latitude: place.latitude, longitude: place.longitude)
+                    )
             }
             return
         }
@@ -85,12 +103,12 @@ struct MyPlaceTab: View {
     }
 }
 
-// MARK: - SamplePlace
+// MARK: - PinInput
 
-private struct SamplePlace {
-    let name: String
-    let coordinate: MapCoordinate
-    let iconAsset: String
+/// `.task(id:)` 트리거 키. 두 값 중 하나라도 바뀌면 핀을 재구성한다.
+private struct PinInput: Equatable {
+    let focusedPlace: ConfirmedPlace?
+    let nearbyPlaces: [NearbyPlace]
 }
 
 // MARK: - Constants
@@ -98,13 +116,4 @@ private struct SamplePlace {
 private enum Constant {
     /// 좌표 정보가 없을 때 사용하는 기본 지도 중심(서울 시청).
     static let defaultCenter = MapCoordinate(latitude: 37.5665, longitude: 126.9780)
-
-    /// 디버깅용 임시 샘플 장소. 실제 데이터 연동 시 제거한다.
-    static let samplePlaces: [SamplePlace] = [
-        SamplePlace(name: "감성카페", coordinate: MapCoordinate(latitude: 37.5665, longitude: 126.9780), iconAsset: "ic_map_pin_cafe"),
-        SamplePlace(name: "남산다이닝", coordinate: MapCoordinate(latitude: 37.5512, longitude: 126.9882), iconAsset: "ic_map_pin_buffet"),
-        SamplePlace(name: "경복궁디저트", coordinate: MapCoordinate(latitude: 37.5796, longitude: 126.9770), iconAsset: "ic_map_pin_dessert"),
-        SamplePlace(name: "명동포차", coordinate: MapCoordinate(latitude: 37.5637, longitude: 126.9850), iconAsset: "ic_map_pin_pub"),
-        SamplePlace(name: "광화문식당", coordinate: MapCoordinate(latitude: 37.5759, longitude: 126.9769), iconAsset: "ic_map_pin_restaurant"),
-    ]
 }

--- a/Projects/Presentation/HomeFeature/Sources/GroupDetail/Tabs/MyPlaceTab/MyPlaceTabFeature.swift
+++ b/Projects/Presentation/HomeFeature/Sources/GroupDetail/Tabs/MyPlaceTab/MyPlaceTabFeature.swift
@@ -5,7 +5,14 @@
 
 import ComposableArchitecture
 
+import CoreDependencies
+import DesignSystem
 import Entity
+import Utill
+
+private enum CancelID {
+    case nearby
+}
 
 @Reducer
 public struct MyPlaceTabFeature {
@@ -22,9 +29,14 @@ public struct MyPlaceTabFeature {
 
     public enum Action {
         case placeFocused(ConfirmedPlace)
+        case mapCenterChanged(MapCoordinate)
+        case nearbyPlacesResponse(stationName: String?, places: [NearbyPlace])
         case nearbyPlaceList(NearbyPlaceListSheetFeature.Action)
         case selectedPlaceDetail(SelectedPlaceDetailSheetFeature.Action)
     }
+
+    @Dependency(\.searchStationsClient) var searchStationsClient
+    @Dependency(\.nearbyPlacesClient) var nearbyPlacesClient
 
     public init() {}
 
@@ -44,6 +56,15 @@ public struct MyPlaceTabFeature {
                 state.focusedPlace = place
                 return .send(.selectedPlaceDetail(.placeFocused(place)))
 
+            case let .mapCenterChanged(coordinate):
+                return fetchNearbyPlaces(latitude: coordinate.latitude, longitude: coordinate.longitude)
+
+            case let .nearbyPlacesResponse(stationName, places):
+                return .send(.nearbyPlaceList(.nearbyPlacesUpdated(stationName: stationName, places: places)))
+
+            case let .nearbyPlaceList(.delegate(.placeTapped(place))):
+                return .send(.placeFocused(place))
+
             case .nearbyPlaceList:
                 return .none
 
@@ -55,5 +76,25 @@ public struct MyPlaceTabFeature {
                 return .none
             }
         }
+    }
+
+    private func fetchNearbyPlaces(latitude: Double, longitude: Double) -> Effect<Action> {
+        let searchStationsClient = self.searchStationsClient
+        let nearbyPlacesClient = self.nearbyPlacesClient
+
+        return .run { send in
+            do {
+                guard let station = try await searchStationsClient.findNearestStation(longitude, latitude) else {
+                    await send(.nearbyPlacesResponse(stationName: nil, places: []))
+                    return
+                }
+
+                let places = try await nearbyPlacesClient.fetchNearbyPlaces(station.y, station.x, 1000, nil)
+                await send(.nearbyPlacesResponse(stationName: station.name, places: places))
+            } catch {
+                Log.debug("근처 장소 조회 실패: \(error.localizedDescription)")
+            }
+        }
+        .cancellable(id: CancelID.nearby, cancelInFlight: true)
     }
 }

--- a/Projects/Presentation/HomeFeature/Sources/MeetingDetail/MapBottomSheet/NearbyPlace/NearbyPlaceListSheet.swift
+++ b/Projects/Presentation/HomeFeature/Sources/MeetingDetail/MapBottomSheet/NearbyPlace/NearbyPlaceListSheet.swift
@@ -60,11 +60,13 @@ private struct NearbyPlaceListHeader: View {
     var body: some View {
         switch mode {
         case .default:
-            Text("신사역")
-                .pretendardCustomFont(textStyle: .titleLarge)
-                .foregroundStyle(Colors.gray900)
-                .padding(.horizontal, Spacing.spacing400)
-                .padding(.bottom, Spacing.spacing250)
+            if let stationName = store.stationName {
+                Text(stationName)
+                    .pretendardCustomFont(textStyle: .titleLarge)
+                    .foregroundStyle(Colors.gray900)
+                    .padding(.horizontal, Spacing.spacing400)
+                    .padding(.bottom, Spacing.spacing250)
+            }
 
         case .pickPlace:
             StationSegmentedControl(
@@ -85,8 +87,18 @@ private struct NearbyPlaceList: View {
     var body: some View {
         switch mode {
         case .default:
-            ForEach(0..<store.placeCount, id: \.self) { _ in
-                PlaceRow()
+            if store.visibleNearbyPlaces.isEmpty {
+                Text("근처 장소가 없어요")
+                    .pretendardCustomFont(textStyle: .bodyMedium)
+                    .foregroundStyle(Colors.gray500)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, Spacing.spacing600)
+            } else {
+                ForEach(store.visibleNearbyPlaces) { place in
+                    PlaceRow(place: place, onTap: {
+                        store.send(.placeRowTapped(place.toConfirmedPlace()))
+                    })
+                }
             }
 
         case .pickPlace:
@@ -98,7 +110,9 @@ private struct NearbyPlaceList: View {
                     .padding(.vertical, Spacing.spacing600)
             } else {
                 ForEach(store.visibleRecommendedPlaces) { place in
-                    PlaceRow(place: place) {
+                    PlaceRow(place: place, onTap: {
+                        store.send(.placeRowTapped(place.toConfirmedPlace()))
+                    }) {
                         PlaceAddButton(
                             isPicked: store.pickedPlaceIds.contains(place.placeId),
                             onTap: { store.send(.placeAddTapped(placeId: place.placeId)) }
@@ -327,5 +341,35 @@ private struct NearbyPlaceOptionFilterButton: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+    }
+}
+
+// MARK: - ConfirmedPlace 변환
+
+/// row 탭을 공통 `placeRowTapped(ConfirmedPlace)`로 흘려보내기 위한 변환.
+/// `ConfirmedPlace`는 두 타입의 공통 부분집합이라 무손실이다.
+private extension NearbyPlace {
+    func toConfirmedPlace() -> ConfirmedPlace {
+        ConfirmedPlace(
+            placeId: placeId,
+            name: name,
+            categoryLabel: categoryLabel,
+            address: address,
+            latitude: latitude,
+            longitude: longitude
+        )
+    }
+}
+
+private extension RecommendedPlace {
+    func toConfirmedPlace() -> ConfirmedPlace {
+        ConfirmedPlace(
+            placeId: placeId,
+            name: name,
+            categoryLabel: categoryLabel,
+            address: address,
+            latitude: latitude,
+            longitude: longitude
+        )
     }
 }

--- a/Projects/Presentation/HomeFeature/Sources/MeetingDetail/MapBottomSheet/NearbyPlace/NearbyPlaceListSheetFeature.swift
+++ b/Projects/Presentation/HomeFeature/Sources/MeetingDetail/MapBottomSheet/NearbyPlace/NearbyPlaceListSheetFeature.swift
@@ -15,6 +15,12 @@ public struct NearbyPlaceListSheetFeature {
         public var isParkingAvailableSelected = false // 주차 가능 여부
         public var isReservableSelected = false // 예약 가능여부
 
+        // MARK: - 역 기반 근처 장소 상태
+        /// 현재 지도 중심에서 가장 가까운 역 이름. 역을 찾지 못하면 `nil`.
+        public var stationName: String?
+        /// 역 기준 반경 내 근처 장소 목록.
+        public var nearbyPlaces: [NearbyPlace] = []
+
         // MARK: - 장소보기(pickPlace) 용도 전용 상태
         /// 역별 추천 장소 그룹 목록. `PickPlaceFeature.onAppear`에서 API 응답으로 채워진다.
         public var stationGroups: [StationRecommendation] = []
@@ -22,10 +28,6 @@ public struct NearbyPlaceListSheetFeature {
         public var selectedStationIndex: Int = 0
         /// 후보로 담은 장소 ID 집합. 역 전환과 무관하게 담기 버튼 상태를 표현한다.
         public var pickedPlaceIds: Set<Int> = []
-
-        // MARK: - default 모드 전용
-        /// default(모임 상세) 모드에서 리스트에 표시할 mock 장소 개수.
-        public var placeCount: Int = 5
 
         public init() {}
 
@@ -38,6 +40,17 @@ public struct NearbyPlaceListSheetFeature {
 
             return stationGroups[selectedStationIndex].places
         }
+
+        /// selectedCategory·주차·예약 필터를 모두 반영해 노출할 근처 장소 목록.
+        /// 각 필터는 선택됐을 때만 적용되고, 여러 필터는 AND로 결합된다.
+        public var visibleNearbyPlaces: [NearbyPlace] {
+            nearbyPlaces.filter { place in
+                let matchesCategory = selectedCategory == .all || place.categoryLabel == selectedCategory
+                let matchesParking = !isParkingAvailableSelected || place.hasParking
+                let matchesReservable = !isReservableSelected || place.reservable
+                return matchesCategory && matchesParking && matchesReservable
+            }
+        }
     }
 
     public enum Action: Equatable {
@@ -46,6 +59,13 @@ public struct NearbyPlaceListSheetFeature {
         case reservableFilterTapped
         case stationSelected(Int)
         case placeAddTapped(placeId: Int)
+        case placeRowTapped(ConfirmedPlace)
+        case nearbyPlacesUpdated(stationName: String?, places: [NearbyPlace])
+        case delegate(Delegate)
+
+        public enum Delegate: Equatable {
+            case placeTapped(ConfirmedPlace)
+        }
     }
 
     public init() {}
@@ -75,6 +95,18 @@ public struct NearbyPlaceListSheetFeature {
                 return .none
 
             case .placeAddTapped:
+                return .none
+
+            case let .placeRowTapped(place):
+                Log.debug("역근처 장소 선택: \(place.name)")
+                return .send(.delegate(.placeTapped(place)))
+
+            case let .nearbyPlacesUpdated(stationName, places):
+                state.stationName = stationName
+                state.nearbyPlaces = places
+                return .none
+
+            case .delegate:
                 return .none
             }
         }

--- a/Projects/Presentation/HomeFeature/Sources/MeetingDetail/MapBottomSheet/NearbyPlace/NearbyPlaceListSheetFeature.swift
+++ b/Projects/Presentation/HomeFeature/Sources/MeetingDetail/MapBottomSheet/NearbyPlace/NearbyPlaceListSheetFeature.swift
@@ -34,11 +34,17 @@ public struct NearbyPlaceListSheetFeature {
         /// pickPlace 모드에서 segmented control에 표시할 역 목록.
         public var stations: [MidpointStation] { stationGroups.map(\.station) }
 
-        /// pickPlace 모드에서 현재 노출할 추천 장소 목록(선택된 역 기준).
+        /// pickPlace 모드에서 현재 노출할 추천 장소 목록(선택된 역 + selectedCategory·주차·예약 필터 반영).
+        /// 각 필터는 선택됐을 때만 적용되고, 여러 필터는 AND로 결합된다.
         public var visibleRecommendedPlaces: [RecommendedPlace] {
             guard stationGroups.indices.contains(selectedStationIndex) else { return [] }
 
-            return stationGroups[selectedStationIndex].places
+            return stationGroups[selectedStationIndex].places.filter { place in
+                let matchesCategory = selectedCategory == .all || place.categoryLabel == selectedCategory
+                let matchesParking = !isParkingAvailableSelected || (place.hasParking ?? false)
+                let matchesReservable = !isReservableSelected || (place.reservable ?? false)
+                return matchesCategory && matchesParking && matchesReservable
+            }
         }
 
         /// selectedCategory·주차·예약 필터를 모두 반영해 노출할 근처 장소 목록.

--- a/Projects/Presentation/HomeFeature/Sources/MeetingDetail/MapBottomSheet/SelectedPlace/SelectedPlaceDetailSheetFeature.swift
+++ b/Projects/Presentation/HomeFeature/Sources/MeetingDetail/MapBottomSheet/SelectedPlace/SelectedPlaceDetailSheetFeature.swift
@@ -4,27 +4,31 @@
 //
 
 import ComposableArchitecture
+import CoreDependencies
 import Entity
 import Foundation
 import UIKit
+import Utill
 
 @Reducer
 public struct SelectedPlaceDetailSheetFeature {
     @ObservableState
     public struct State: Equatable, Sendable {
-        public let name: String
-        public let distanceText: String
-        public let categoryName: String
-        public let closedDayText: String
-        public let businessHoursText: String
-        public let roadAddress: String
-        public let lotAddress: String
+        public var placeId: Int
+        public var name: String
+        public var distanceText: String
+        public var categoryName: String
+        public var closedDayText: String
+        public var businessHoursText: String
+        public var roadAddress: String
+        public var lotAddress: String
 
         var naverMapSearchQuery: String {
             name
         }
 
         public init(
+            placeId: Int,
             name: String,
             distanceText: String,
             categoryName: String,
@@ -33,6 +37,7 @@ public struct SelectedPlaceDetailSheetFeature {
             roadAddress: String,
             lotAddress: String
         ) {
+            self.placeId = placeId
             self.name = name
             self.distanceText = distanceText
             self.categoryName = categoryName
@@ -43,6 +48,7 @@ public struct SelectedPlaceDetailSheetFeature {
         }
 
         public static let mock = State(
+            placeId: 0,
             name: "서촌김씨",
             distanceText: "18km",
             categoryName: "디저트",
@@ -55,9 +61,12 @@ public struct SelectedPlaceDetailSheetFeature {
 
     public enum Action: Equatable {
         case placeFocused(ConfirmedPlace)
+        case placeDetailResponse(PlaceDetail)
         case closeButtonTapped
         case naverMapButtonTapped
     }
+
+    @Dependency(\.placeDetailsClient) private var placeDetailsClient
 
     public init() {}
 
@@ -66,6 +75,7 @@ public struct SelectedPlaceDetailSheetFeature {
             switch action {
             case let .placeFocused(place):
                 state = State(
+                    placeId: place.placeId,
                     name: place.name,
                     distanceText: Constant.placeholder,
                     categoryName: place.categoryLabel.title,
@@ -74,6 +84,27 @@ public struct SelectedPlaceDetailSheetFeature {
                     roadAddress: place.address,
                     lotAddress: Constant.placeholder
                 )
+
+                let placeDetailsClient = self.placeDetailsClient
+                let placeId = place.placeId
+                return .run { send in
+                    do {
+                        let details = try await placeDetailsClient.fetchPlaceDetails(ids: [placeId])
+                        guard let detail = details.first else { return }
+
+                        await send(.placeDetailResponse(detail))
+                    } catch {
+                        Log.debug("장소 상세 조회 실패: \(error.localizedDescription)")
+                    }
+                }
+                .cancellable(id: CancelID.detail, cancelInFlight: true)
+
+            case let .placeDetailResponse(detail):
+                state.categoryName = detail.categoryLabel.title
+                state.closedDayText = detail.holiday
+                state.businessHoursText = detail.businessHours
+                state.roadAddress = detail.roadAddress
+                state.lotAddress = detail.address
                 return .none
 
             case .closeButtonTapped:
@@ -94,6 +125,10 @@ public struct SelectedPlaceDetailSheetFeature {
 private enum Constant {
     /// `ConfirmedPlace`에 대응 정보가 없는 필드의 표시값.
     static let placeholder = "-"
+}
+
+private enum CancelID {
+    case detail
 }
 
 @MainActor

--- a/Projects/Presentation/HomeFeature/Sources/PickPlace/PickPlaceFeature.swift
+++ b/Projects/Presentation/HomeFeature/Sources/PickPlace/PickPlaceFeature.swift
@@ -30,8 +30,8 @@ public struct PickPlaceFeature {
         public var hasLoadedRecommendations = false
 
         public init(
-            members: [PickPlaceMember] = PickPlaceMember.mock,
-            pickedPlaces: [PickedPlace] = PickedPlace.mock,
+            members: [PickPlaceMember] = [],
+            pickedPlaces: [PickedPlace] = [],
             isHost: Bool = false,
             meetingId: Int = 0
         ) {

--- a/Projects/Presentation/HomeFeature/Sources/PickPlace/PickPlaceView.swift
+++ b/Projects/Presentation/HomeFeature/Sources/PickPlace/PickPlaceView.swift
@@ -75,7 +75,7 @@ private struct PickPlaceViewPreview: View {
         pickedPlaces: [PickedPlace] = PickedPlace.mock,
         isHost: Bool = false
     ) {
-        var state = PickPlaceFeature.State(pickedPlaces: pickedPlaces, isHost: isHost)
+        var state = PickPlaceFeature.State(members: PickPlaceMember.mock, pickedPlaces: pickedPlaces, isHost: isHost)
         state.selectedSubTabIndex = selectedSubTabIndex
         state.recommendedPlaceMap.stationRecommendations = StationRecommendation.mock
         state.recommendedPlaceMap.nearbyPlaceList.stationGroups = StationRecommendation.mock

--- a/Projects/Presentation/HomeFeature/Sources/PickPlace/Tabs/PickedPlaceTabFeature.swift
+++ b/Projects/Presentation/HomeFeature/Sources/PickPlace/Tabs/PickedPlaceTabFeature.swift
@@ -18,8 +18,8 @@ public struct PickedPlaceTabFeature {
         public let isHost: Bool
 
         public init(
-            members: [PickPlaceMember] = PickPlaceMember.mock,
-            pickedPlaces: [PickedPlace] = PickedPlace.mock,
+            members: [PickPlaceMember] = [],
+            pickedPlaces: [PickedPlace] = [],
             isHost: Bool = false
         ) {
             self.members = members

--- a/Projects/Presentation/HomeFeature/Sources/PickPlace/Tabs/RecommendedPlaceMapTab.swift
+++ b/Projects/Presentation/HomeFeature/Sources/PickPlace/Tabs/RecommendedPlaceMapTab.swift
@@ -45,21 +45,34 @@ struct RecommendedPlaceMapTab: View {
         return MapCoordinate(latitude: station.latitude, longitude: station.longitude)
     }
 
+    /// 지도 카메라 포커싱 좌표. 포커싱 장소가 있으면 그 좌표, 없으면 선택된 역 좌표.
+    private var focusedCoordinate: MapCoordinate? {
+        guard let place = store.focusedPlace else { return selectedStationCoordinate }
+
+        return MapCoordinate(latitude: place.latitude, longitude: place.longitude)
+    }
+
     var body: some View {
         ZStack(alignment: .bottom) {
             KakaoMap(
                 pins: recommendedPlacePins,
                 initialCenter: initialCenter,
-                focusedCoordinate: selectedStationCoordinate,
+                focusedCoordinate: focusedCoordinate,
                 focusBottomInset: sheetCoveredHeight
             )
             .ignoresSafeArea()
 
             MapBottomSheet(detents: [.ratio(0.4), .full], initialDetent: .ratio(0.4)) {
-                NearbyPlaceListSheet(
-                    store: store.scope(state: \.nearbyPlaceList, action: \.nearbyPlaceList),
-                    mode: .pickPlace
-                )
+                if store.focusedPlace != nil {
+                    SelectedPlaceDetailSheet(
+                        store: store.scope(state: \.selectedPlaceDetail, action: \.selectedPlaceDetail)
+                    )
+                } else {
+                    NearbyPlaceListSheet(
+                        store: store.scope(state: \.nearbyPlaceList, action: \.nearbyPlaceList),
+                        mode: .pickPlace
+                    )
+                }
             }
             .onVisibleHeightChanged { sheetCoveredHeight = $0 }
         }

--- a/Projects/Presentation/HomeFeature/Sources/PickPlace/Tabs/RecommendedPlaceMapTabFeature.swift
+++ b/Projects/Presentation/HomeFeature/Sources/PickPlace/Tabs/RecommendedPlaceMapTabFeature.swift
@@ -15,6 +15,10 @@ public struct RecommendedPlaceMapTabFeature {
         public var stationRecommendations: [StationRecommendation] = []
         /// 시트에서 선택된 역 인덱스. `nearbyPlaceList`의 선택을 미러링한다.
         public var selectedStationIndex: Int = 0
+        /// 포커싱할 장소. 설정 시 지도 카메라를 이 장소로 맞추고 상세 시트로 전환한다.
+        public var focusedPlace: ConfirmedPlace?
+        /// 포커싱 장소가 있을 때 표시할 장소 상세 시트.
+        public var selectedPlaceDetail: SelectedPlaceDetailSheetFeature.State = .mock
 
         public init() {}
 
@@ -32,7 +36,9 @@ public struct RecommendedPlaceMapTabFeature {
     }
 
     public enum Action {
+        case placeFocused(ConfirmedPlace)
         case nearbyPlaceList(NearbyPlaceListSheetFeature.Action)
+        case selectedPlaceDetail(SelectedPlaceDetailSheetFeature.Action)
     }
 
     public init() {}
@@ -42,13 +48,31 @@ public struct RecommendedPlaceMapTabFeature {
             NearbyPlaceListSheetFeature()
         }
 
+        Scope(state: \.selectedPlaceDetail, action: \.selectedPlaceDetail) {
+            SelectedPlaceDetailSheetFeature()
+        }
+
         Reduce { state, action in
             switch action {
             case let .nearbyPlaceList(.stationSelected(index)):
                 state.selectedStationIndex = index
                 return .none
 
+            case let .nearbyPlaceList(.delegate(.placeTapped(place))):
+                return .send(.placeFocused(place))
+
             case .nearbyPlaceList:
+                return .none
+
+            case let .placeFocused(place):
+                state.focusedPlace = place
+                return .send(.selectedPlaceDetail(.placeFocused(place)))
+
+            case .selectedPlaceDetail(.closeButtonTapped):
+                state.focusedPlace = nil
+                return .none
+
+            case .selectedPlaceDetail:
                 return .none
             }
         }


### PR DESCRIPTION
## 작업 내용

`MyPlaceTab` 지도 이동 기반 근처 역·장소 조회 플로우(이슈 #90)와, 선택한 장소의 상세 정보 조회 기능을 함께 구현했습니다.

### 1. 근처 역·장소 조회 (이슈 #90)
- 지도 이동(`onCenterChanged`) → 중심 좌표로 근처 역 조회(`findNearestStation` 재사용) → 역 근처 장소 GET API 연동
- 조회 결과를 지도 핀·`NearbyPlaceListSheet` 바텀시트 리스트에 반영, 헤더 역명 동적화
- mock 핀/리스트 제거 후 실제 데이터 파이프라인 연결

### 2. 장소 상세 조회 (추가 작업)
- `placeId` 목록으로 장소 상세 정보를 조회하는 `GET /api/v1/places` 독립 도메인(`PlaceDetail`) 신설
- `SelectedPlaceDetailSheet` 진입 시 상세 API를 호출해 영업시간·휴무일·주소 등을 채우도록 연동
- 배열 쿼리를 `noBrackets`(`ids=1&ids=2`) 형식으로 인코딩하는 네트워크 케이스 추가

## 변경 사항

계층별로 기존 `NearbyPlaces*` 패턴을 준수했습니다.

- **Domain**: `PlaceDetail` Entity, `PlaceDetailsRepositoryProtocol`, `FetchPlaceDetailsUseCase`
- **Data**: `PlaceDetailResponseDTO`(+`toEntity`), `PlacesEndpoint`, `PlaceDetailsRepositoryImpl`, `FetchPlaceDetailsUseCaseImpl`
- **Core/App**: `PlaceDetailsClient`, `PlaceDetailsFactory`, `BangawoApp` 주입
- **Network**: `APITask`/`NetworkManager`에 `requestParametersWithEncoding` 케이스 추가
- **Presentation**: `SelectedPlaceDetailSheetFeature` 상세 조회 연동, 근처 장소 조회 관련 Feature/View

## To Reviewer

- 상세 조회 호출 위치는 결과가 시트 내부에서만 소비되어 TCA Navigation Ownership 컨벤션에 따라 자식 `SelectedPlaceDetailSheetFeature`에 두었습니다.
- `distanceText`는 응답 스키마에 거리 정보가 없어 placeholder를 유지했고, `naverUrl`은 현재 사용처가 없어 이번 범위에서 제외했습니다.
- 시뮬레이터 대상은 TCA 매크로 캐시 이슈가 있어 디바이스 대상(`CODE_SIGNING_ALLOWED=NO`)으로 빌드 성공을 확인했습니다.
- 변경량이 권장 500라인을 초과하지만, 근처 조회와 상세 조회가 한 브랜치에 함께 담겨 있어 하나의 PR로 올립니다.

Closes #90
