### PR TITLE
[FIX]: 애플 로그인 권한 설정 연결

### DIFF
--- a/Projects/App/Project.swift
+++ b/Projects/App/Project.swift
@@ -27,6 +27,7 @@ let project = Project.makeAppModule(
   sources: ["Sources/**"],
   resources: ["Resources/**"],
   infoPlist: .appInfoPlist,
+  entitlements: .file(path: "Bangawo.entitlements"),
   schemes: [
     // 테스트 플랜 스킴: 커스텀 구성명 사용 (.debug / .prod 중 택1)
     Scheme.makeTestPlanScheme(target: .debug, name: Project.Environment.appName),


### PR DESCRIPTION
## 📌 Summary

Apple 로그인 요청 시 `AuthorizationError 1000`이 발생하던 문제를 수정했습니다.

Tuist 프로젝트 생성 과정에서 `Bangawo.entitlements`가 앱 타깃에 연결되지 않아  
Sign in with Apple Capability가 사라지는 것이 원인이었습니다.

## 🛠 Changes

- `Project.swift`에 `Bangawo.entitlements` 연결
- Tuist 프로젝트 재생성 후 모든 앱 타깃의 `CODE_SIGN_ENTITLEMENTS` 설정 확인
- 프로젝트를 다시 생성해도 Sign in with Apple Capability가 유지되도록 수정