### PR TITLE
[FEAT] 그룹 종료 API 연동 및 홈 리스트 정리

### DIFF
--- a/Plugins/ProjectTemplatePlugin/ProjectDescriptionHelpers/Setting/Project+Settings.swift
+++ b/Plugins/ProjectTemplatePlugin/ProjectDescriptionHelpers/Setting/Project+Settings.swift
@@ -16,7 +16,7 @@ extension Settings {
   ) -> SettingsDictionary {
     return SettingsDictionary()
       .setProductName(appName)
-      .setCFBundleDisplayName(displayName)
+      .setBundleDisplayName(displayName)
       .setOtherLdFlags("-ObjC -all_load")
       .setDebugInformationFormat("dwarf-with-dsym")
       .setCodeSignStyle(codeSignStyle)
@@ -37,7 +37,7 @@ extension Settings {
   public static let appMainSetting: Settings = .settings(
     base: SettingsDictionary()
       .setProductName(Project.Environment.appName)
-      .setCFBundleDisplayName(Project.Environment.appName)
+      .setBundleDisplayName(Project.Environment.appName)
       .setMarketingVersion(.appVersion())
       .setEnableBackgroundModes()
       .setArchs()

--- a/Plugins/ProjectTemplatePlugin/ProjectDescriptionHelpers/Setting/SettingDictionary.swift
+++ b/Plugins/ProjectTemplatePlugin/ProjectDescriptionHelpers/Setting/SettingDictionary.swift
@@ -15,8 +15,8 @@ public extension SettingsDictionary {
     return self.merging(["PRODUCT_NAME": SettingValue(stringLiteral: value)]) { (_, new) in new }
   }
   
-  func setCFBundleDisplayName(_ value: String) -> SettingsDictionary {
-    return self.merging(["CFBundleDisplayName": SettingValue(stringLiteral: value)]) { (_, new) in new }
+  func setBundleDisplayName(_ value: String) -> SettingsDictionary {
+    return self.merging(["BUNDLE_DISPLAY_NAME": SettingValue(stringLiteral: value)]) { (_, new) in new }
   }
   
   func setMarketingVersion(_ value: String) -> SettingsDictionary {

--- a/Projects/App/Sources/Factory/GroupFactory.swift
+++ b/Projects/App/Sources/Factory/GroupFactory.swift
@@ -16,13 +16,15 @@ enum GroupFactory {
         let fetchDetailUseCase = FetchGroupDetailUseCaseImpl(repository: repository)
         let updateAttendanceUseCase = UpdateAttendanceUseCaseImpl(repository: repository)
         let issueInviteCodeUseCase = IssueInviteCodeUseCaseImpl(repository: repository)
+        let closeGroupUseCase = CloseGroupUseCaseImpl(repository: repository)
         return .live(
             fetchUseCase: fetchUseCase,
             createUseCase: createUseCase,
             hostPickMeetingDateUseCase: hostPickMeetingDateUseCase,
             fetchDetailUseCase: fetchDetailUseCase,
             updateAttendanceUseCase: updateAttendanceUseCase,
-            issueInviteCodeUseCase: issueInviteCodeUseCase
+            issueInviteCodeUseCase: issueInviteCodeUseCase,
+            closeGroupUseCase: closeGroupUseCase
         )
     }
 }

--- a/Projects/Core/CoreDependencies/Sources/Group/GroupClient.swift
+++ b/Projects/Core/CoreDependencies/Sources/Group/GroupClient.swift
@@ -17,6 +17,7 @@ public struct GroupClient: Sendable {
     public var fetchGroupDetail: @Sendable (_ meetingId: Int) async throws -> GroupDetail
     public var updateAttendance: @Sendable (_ meetingId: Int, _ attendanceStatus: AttendanceStatus) async throws -> Void
     public var issueInviteCode: @Sendable (_ groupId: Int) async throws -> String
+    public var closeGroup: @Sendable (_ groupId: Int) async throws -> Void
 }
 
 public extension GroupClient {
@@ -26,7 +27,8 @@ public extension GroupClient {
         hostPickMeetingDateUseCase: any HostPickMeetingDateUseCase,
         fetchDetailUseCase: any FetchGroupDetailUseCase,
         updateAttendanceUseCase: any UpdateAttendanceUseCase,
-        issueInviteCodeUseCase: any IssueInviteCodeUseCase
+        issueInviteCodeUseCase: any IssueInviteCodeUseCase,
+        closeGroupUseCase: any CloseGroupUseCase
     ) -> Self {
         Self(
             fetchGroups: { try await fetchUseCase.execute() },
@@ -44,6 +46,9 @@ public extension GroupClient {
             },
             issueInviteCode: { groupId in
                 try await issueInviteCodeUseCase.execute(groupId: groupId)
+            },
+            closeGroup: { groupId in
+                try await closeGroupUseCase.execute(groupId: groupId)
             }
         )
     }
@@ -57,7 +62,8 @@ extension GroupClient: DependencyKey {
             hostPickMeetingDate: { _, _ in throw GroupClientError.notImplemented },
             fetchGroupDetail: { _ in throw GroupClientError.notImplemented },
             updateAttendance: { _, _ in throw GroupClientError.notImplemented },
-            issueInviteCode: { _ in throw GroupClientError.notImplemented }
+            issueInviteCode: { _ in throw GroupClientError.notImplemented },
+            closeGroup: { _ in throw GroupClientError.notImplemented }
         )
     }
 
@@ -71,7 +77,8 @@ extension GroupClient: DependencyKey {
         hostPickMeetingDate: { _, _ in },
         fetchGroupDetail: { _ in previewGroupDetail },
         updateAttendance: { _, _ in },
-        issueInviteCode: { _ in "PREVIEW-INVITE-CODE" }
+        issueInviteCode: { _ in "PREVIEW-INVITE-CODE" },
+        closeGroup: { _ in }
     )
 }
 

--- a/Projects/Data/API/Sources/GroupEndpoint.swift
+++ b/Projects/Data/API/Sources/GroupEndpoint.swift
@@ -15,6 +15,7 @@ public enum GroupEndpoint: EndPoint {
     case fetchGroupDetail(meetingId: Int)
     case updateAttendance(meetingId: Int, UpdateAttendanceRequestDTO)
     case issueInviteCode(groupId: Int)
+    case closeGroup(groupId: Int)
 
     public var baseURL: String { APIConfiguration.serverBaseURL }
 
@@ -27,6 +28,7 @@ public enum GroupEndpoint: EndPoint {
         case .fetchGroupDetail(let meetingId): return "/api/v1/meetings/\(meetingId)"
         case .updateAttendance(let meetingId, _): return "/api/v1/meetings/\(meetingId)/participants/me/attendance"
         case .issueInviteCode(let groupId): return "/api/v1/groups/\(groupId)/invite"
+        case .closeGroup(let groupId): return "/api/v1/groups/\(groupId)/close"
         }
     }
 
@@ -35,7 +37,7 @@ public enum GroupEndpoint: EndPoint {
         case .fetchGroups: return .get
         case .createGroup, .hostPickMeetingDate: return .post
         case .fetchGroupDetail: return .get
-        case .updateAttendance: return .patch
+        case .updateAttendance, .closeGroup: return .patch
         case .issueInviteCode: return .post
         }
     }
@@ -48,6 +50,7 @@ public enum GroupEndpoint: EndPoint {
         case .fetchGroupDetail: return .requestPlain
         case .updateAttendance(_, let dto): return .requestJSONEncodable(body: dto)
         case .issueInviteCode: return .requestPlain
+        case .closeGroup: return .requestPlain
         }
     }
 }

--- a/Projects/Data/DataUseCase/Sources/Group/CloseGroupUseCaseImpl.swift
+++ b/Projects/Data/DataUseCase/Sources/Group/CloseGroupUseCaseImpl.swift
@@ -1,0 +1,19 @@
+//
+//  CloseGroupUseCaseImpl.swift
+//  DataUseCase
+//
+
+import DataInterface
+import UseCase
+
+public final class CloseGroupUseCaseImpl: CloseGroupUseCase {
+    private let repository: GroupRepositoryProtocol
+
+    public init(repository: GroupRepositoryProtocol) {
+        self.repository = repository
+    }
+
+    public func execute(groupId: Int) async throws {
+        try await repository.closeGroup(groupId: groupId)
+    }
+}

--- a/Projects/Data/DataUseCase/Sources/Group/FetchGroupsUseCaseImpl.swift
+++ b/Projects/Data/DataUseCase/Sources/Group/FetchGroupsUseCaseImpl.swift
@@ -15,6 +15,6 @@ public final class FetchGroupsUseCaseImpl: FetchGroupsUseCase {
     }
 
     public func execute() async throws -> [Group] {
-        try await repository.fetchGroups()
+        try await repository.fetchGroups().filter { $0.listStatus != .closed }
     }
 }

--- a/Projects/Data/Repository/Sources/GroupRepositoryImpl.swift
+++ b/Projects/Data/Repository/Sources/GroupRepositoryImpl.swift
@@ -50,4 +50,10 @@ public final class GroupRepositoryImpl: GroupRepositoryProtocol {
         )
         return response.inviteCode
     }
+
+    public func closeGroup(groupId: Int) async throws {
+        try await NetworkManager.shared.requestVoid(
+            GroupEndpoint.closeGroup(groupId: groupId)
+        )
+    }
 }

--- a/Projects/Domain/DataInterface/Sources/GroupRepositoryProtocol.swift
+++ b/Projects/Domain/DataInterface/Sources/GroupRepositoryProtocol.swift
@@ -12,4 +12,5 @@ public protocol GroupRepositoryProtocol: Sendable {
     func fetchGroupDetail(meetingId: Int) async throws -> GroupDetail
     func updateAttendance(meetingId: Int, attendanceStatus: AttendanceStatus) async throws
     func issueInviteCode(groupId: Int) async throws -> String
+    func closeGroup(groupId: Int) async throws
 }

--- a/Projects/Domain/Entity/Sources/Group/Group.swift
+++ b/Projects/Domain/Entity/Sources/Group/Group.swift
@@ -67,14 +67,14 @@ public struct GroupMember: Identifiable, Equatable, Sendable {
 public enum GroupListStatus: Equatable, Sendable {
     case inProgress
     case confirmed
-    case ended
+    case closed
     case unknown(String)
 
     public init(rawValue: String) {
         switch rawValue {
         case "IN_PROGRESS": self = .inProgress
         case "CONFIRMED": self = .confirmed
-        case "ENDED": self = .ended
+        case "CLOSED": self = .closed
         default: self = .unknown(rawValue)
         }
     }

--- a/Projects/Domain/UseCase/Sources/Group/CloseGroupUseCase.swift
+++ b/Projects/Domain/UseCase/Sources/Group/CloseGroupUseCase.swift
@@ -1,0 +1,8 @@
+//
+//  CloseGroupUseCase.swift
+//  UseCase
+//
+
+public protocol CloseGroupUseCase: Sendable {
+    func execute(groupId: Int) async throws
+}

--- a/Projects/Presentation/HomeFeature/Sources/GroupDetail/GroupDetailFeature.swift
+++ b/Projects/Presentation/HomeFeature/Sources/GroupDetail/GroupDetailFeature.swift
@@ -21,6 +21,7 @@ public struct GroupDetailFeature {
         public var isInviteSheetPresented = false
         /// 발급받은 초대코드. 최초 발급 후 재사용해 중복 호출을 막는다.
         public var inviteCode: String?
+        @Presents public var alert: AlertState<Action.Alert>?
 
         public init(group: Group) {
             self.home = HomeTabFeature.State(group: group)
@@ -44,7 +45,10 @@ public struct GroupDetailFeature {
         case inviteButtonTapped
         case inviteLinkCopyTapped
         case kakaoShareTapped
+        case endGroupTapped
+        case leaveGroupTapped
         case inviteCodeIssued(Result<String, Error>, InviteIntent)
+        case alert(PresentationAction<Alert>)
         case home(HomeTabFeature.Action)
         case myPlace(MyPlaceTabFeature.Action)
         case delegate(Delegate)
@@ -56,6 +60,11 @@ public struct GroupDetailFeature {
         /// 장소 투표 후보 담기 화면으로 진입.
         case startPickPlace(isHost: Bool, meetingId: Int)
         }
+
+        public enum Alert: Equatable {
+            case confirmEndGroup
+            case confirmLeaveGroup
+        }
     }
 
     /// 초대코드 발급 후 수행할 동작.
@@ -66,6 +75,7 @@ public struct GroupDetailFeature {
 
     @Dependency(\.groupClient) private var groupClient
     @Dependency(\.groupInvitationShareClient) private var groupInvitationShareClient
+    @Dependency(\.dismiss) private var dismiss
 
     public init() {}
 
@@ -91,6 +101,33 @@ public struct GroupDetailFeature {
 
             case .inviteButtonTapped:
                 state.isInviteSheetPresented = true
+                return .none
+
+            case .endGroupTapped:
+                state.alert = Self.endGroupAlert(groupName: state.home.group.name)
+                return .none
+
+            case .leaveGroupTapped:
+                state.alert = Self.leaveGroupAlert(groupName: state.home.group.name)
+                return .none
+
+            case .alert(.presented(.confirmEndGroup)):
+                let groupId = state.home.group.id
+                let groupClient = groupClient
+                let dismiss = dismiss
+                return .run { _ in
+                    do {
+                        try await groupClient.closeGroup(groupId)
+                        await dismiss()
+                    } catch {
+                        Log.debug("그룹 종료 실패: \(error.localizedDescription)")
+                    }
+                }
+
+            case .alert(.presented(.confirmLeaveGroup)):
+                return .none
+
+            case .alert:
                 return .none
 
             case .inviteLinkCopyTapped:
@@ -132,6 +169,33 @@ public struct GroupDetailFeature {
 
             case .home, .myPlace, .delegate:
                 return .none
+            }
+        }
+        .ifLet(\.$alert, action: \.alert)
+    }
+
+    private static func endGroupAlert(groupName: String) -> AlertState<Action.Alert> {
+        AlertState {
+            TextState("\(groupName)을 종료하시겠습니까?")
+        } actions: {
+            ButtonState(action: .confirmEndGroup) {
+                TextState("종료할래요")
+            }
+            ButtonState(role: .cancel) {
+                TextState("아니요")
+            }
+        }
+    }
+
+    private static func leaveGroupAlert(groupName: String) -> AlertState<Action.Alert> {
+        AlertState {
+            TextState("\(groupName)을 나가시겠습니까?")
+        } actions: {
+            ButtonState(action: .confirmLeaveGroup) {
+                TextState("나갈래요")
+            }
+            ButtonState(role: .cancel) {
+                TextState("아니요")
             }
         }
     }

--- a/Projects/Presentation/HomeFeature/Sources/GroupDetail/GroupDetailFeature.swift
+++ b/Projects/Presentation/HomeFeature/Sources/GroupDetail/GroupDetailFeature.swift
@@ -47,6 +47,7 @@ public struct GroupDetailFeature {
         case kakaoShareTapped
         case endGroupTapped
         case leaveGroupTapped
+        case groupClosed(Result<Void, Error>)
         case inviteCodeIssued(Result<String, Error>, InviteIntent)
         case alert(PresentationAction<Alert>)
         case home(HomeTabFeature.Action)
@@ -114,15 +115,18 @@ public struct GroupDetailFeature {
             case .alert(.presented(.confirmEndGroup)):
                 let groupId = state.home.group.id
                 let groupClient = groupClient
-                let dismiss = dismiss
-                return .run { _ in
-                    do {
+                return .run { send in
+                    await send(.groupClosed(Result {
                         try await groupClient.closeGroup(groupId)
-                        await dismiss()
-                    } catch {
-                        Log.debug("그룹 종료 실패: \(error.localizedDescription)")
-                    }
+                    }))
                 }
+
+            case .groupClosed(.success):
+                return .run { _ in await dismiss() }
+
+            case .groupClosed(.failure):
+                state.alert = Self.closeGroupErrorAlert()
+                return .none
 
             case .alert(.presented(.confirmLeaveGroup)):
                 return .none
@@ -196,6 +200,16 @@ public struct GroupDetailFeature {
             }
             ButtonState(role: .cancel) {
                 TextState("아니요")
+            }
+        }
+    }
+
+    private static func closeGroupErrorAlert() -> AlertState<Action.Alert> {
+        AlertState {
+            TextState("그룹 종료에 실패했습니다.")
+        } actions: {
+            ButtonState(role: .cancel) {
+                TextState("확인")
             }
         }
     }

--- a/Projects/Presentation/HomeFeature/Sources/GroupDetail/GroupDetailView.swift
+++ b/Projects/Presentation/HomeFeature/Sources/GroupDetail/GroupDetailView.swift
@@ -16,6 +16,8 @@ public struct GroupDetailView: View {
 
     @Environment(\.dismiss) private var dismiss
 
+    @State private var isMoreMenuPresented = false
+
     public init(store: StoreOf<GroupDetailFeature>) {
         self.store = store
     }
@@ -27,7 +29,7 @@ public struct GroupDetailView: View {
                 leadingAction: { dismiss() },
                 trailingIcons: [
                     NavigationIconItem(icon: .userPlus24) { store.send(.inviteButtonTapped) },
-                    NavigationIconItem(icon: .verticalMenu24) {}
+                    NavigationIconItem(icon: .verticalMenu24) { isMoreMenuPresented.toggle() }
                 ]
             )
 
@@ -42,6 +44,23 @@ public struct GroupDetailView: View {
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
         .background(Colors.gray200)
+        .overlay {
+            if isMoreMenuPresented {
+                ZStack(alignment: .topTrailing) {
+                    Color.clear
+                        .contentShape(Rectangle())
+                        .onTapGesture { isMoreMenuPresented = false }
+
+                    DesignSystem.Menu(items: [
+                        .init(label: store.home.isMeHost ? "그룹 종료" : "그룹 나가기") {
+                            store.send(store.home.isMeHost ? .endGroupTapped : .leaveGroupTapped)
+                            isMoreMenuPresented = false
+                        }
+                    ])
+                    .offset(x: Metric.moreMenuOffsetX, y: Metric.moreMenuOffsetY)
+                }
+            }
+        }
         .toolbar(.hidden, for: .navigationBar)
         .menuSheet(
             isPresented: $store.isInviteSheetPresented,
@@ -55,6 +74,7 @@ public struct GroupDetailView: View {
                 }
             ]
         )
+        .alert($store.scope(state: \.alert, action: \.alert))
     }
 
     private var tabBinding: Binding<Int> {
@@ -63,6 +83,15 @@ public struct GroupDetailView: View {
             set: { store.send(.tabSelected($0)) }
         )
     }
+}
+
+// MARK: - Metric
+
+private enum Metric {
+    /// 케밥 아이콘 트레일링 인셋(`NavigationPage`의 trailing padding)만큼 우측에서 안쪽으로 정렬.
+    static let moreMenuOffsetX: CGFloat = -Spacing.spacing300
+    /// `NavigationPage` 높이(`Sizing.sizing450` + 상하 `Spacing.spacing150`) 아래로 내려 아이콘 바로 밑에 배치.
+    static let moreMenuOffsetY: CGFloat = Sizing.sizing450 + Spacing.spacing150 * 2 + Spacing.spacing100
 }
 
 // MARK: - Tab Content

--- a/Projects/Presentation/HomeFeature/Sources/Home/HomeFeature.swift
+++ b/Projects/Presentation/HomeFeature/Sources/Home/HomeFeature.swift
@@ -81,8 +81,9 @@ public struct HomeFeature {
                 return fetchGroupsEffect()
 
             case .groupsResponse(.success(let groups)):
-                state.groups = groups
-                if (1...2).contains(groups.count) {
+                let visibleGroups = groups.filter { $0.listStatus != .closed }
+                state.groups = visibleGroups
+                if (1...2).contains(visibleGroups.count) {
                     state.inviteCardDesign = withRandomNumberGenerator {
                         Bool.random(using: &$0) ? .design1 : .design2
                     }

--- a/Projects/Presentation/HomeFeature/Sources/Home/HomeFeature.swift
+++ b/Projects/Presentation/HomeFeature/Sources/Home/HomeFeature.swift
@@ -81,9 +81,8 @@ public struct HomeFeature {
                 return fetchGroupsEffect()
 
             case .groupsResponse(.success(let groups)):
-                let visibleGroups = groups.filter { $0.listStatus != .closed }
-                state.groups = visibleGroups
-                if (1...2).contains(visibleGroups.count) {
+                state.groups = groups
+                if (1...2).contains(groups.count) {
                     state.inviteCardDesign = withRandomNumberGenerator {
                         Bool.random(using: &$0) ? .design1 : .design2
                     }

--- a/Projects/Presentation/HomeFeature/Sources/Home/HomeView.swift
+++ b/Projects/Presentation/HomeFeature/Sources/Home/HomeView.swift
@@ -22,21 +22,23 @@ public struct HomeView: View {
         NavigationStack(path: $store.scope(state: \.path, action: \.path)) {
             ZStack(alignment: .bottomTrailing) {
                 VStack(spacing: 0) {
-                    NavigationMain(
-                        background: .clear,
-                        trailingIcons: [
-                            NavigationIconItem(
-                                icon: .bell24,
-                                showsBadge: store.hasUnreadNotifications
-                            ) { store.send(.notificationButtonTapped) },
-                            NavigationIconItem(icon: .user24) {
-                                store.send(.myPageButtonTapped)
-                            }
-                        ]
-                    )
+                    // FIXME: 알림/마이페이지 버튼은 동작이 정의되지 않아(탭 시 no-op) 심사 리젝 방지를 위해 임시 숨김.
+                    // 각 기능 구현 시 아래 trailingIcons 를 복구한다.
+                    // trailingIcons: [
+                    //     NavigationIconItem(
+                    //         icon: .bell24,
+                    //         showsBadge: store.hasUnreadNotifications
+                    //     ) { store.send(.notificationButtonTapped) },
+                    //     NavigationIconItem(icon: .user24) {
+                    //         store.send(.myPageButtonTapped)
+                    //     }
+                    // ]
+                    NavigationMain(background: .clear)
 
                     Tab(
-                        labels: ["모임", "리마인더"],
+                        // FIXME: 리마인더 탭은 화면 미구현(선택 시 빈 화면)으로 심사 리젝 방지를 위해 임시 숨김.
+                        // 리마인더 화면 구현 시 labels 에 "리마인더" 를 복구한다.
+                        labels: ["모임"],
                         selectedIndex: Binding(
                             get: { store.selectedTabIndex },
                             set: { store.send(.tabSelected($0)) }


### PR DESCRIPTION
## Summary

그룹(모임) 종료 API를 연동하고, 종료된 그룹이 홈 리스트에 노출되지 않도록 정리했습니다.
GroupDetail 상단 케밥 메뉴에 종료/나가기 액션을 붙여 종료 플로우를 완성했습니다.

Closes #101

## 주요 변경 사항

- `GroupClient`에 `closeGroup` 메서드 추가 및 Domain UseCase / Repository / API Endpoint 조립(Factory)
- 케밥 메뉴 액션 연결 → 종료/나가기 알럿 노출 및 종료 API 호출
- 종료된 그룹은 홈 리스트 노출에서 제외
- 홈 미구현 네비 버튼·리마인더 탭 임시 숨김 (#102)
- 앱 표시 이름 미적용 빌드 세팅 키 수정

## To Reviewer

- 대상 브랜치는 `develop`입니다.
- 종료 API 응답 처리 후 홈 복귀/목록 갱신 흐름을 확인해 주시면 좋겠습니다.
