### PR TITLE
[FIX] TestFlight Deploy CI의 tuisttool OS 불일치 수정

### DIFF
--- a/.github/workflows/testflight-deploy.yml
+++ b/.github/workflows/testflight-deploy.yml
@@ -30,6 +30,11 @@ jobs:
       - name: Setup mise & tuist
         uses: jdx/mise-action@v2
 
+      # 커밋된 tuisttool 바이너리는 로컬 macOS 26 기준으로 빌드되어 macos-15 러너에서 로드 불가
+      # → 러너 OS에 맞게 소스에서 재컴파일
+      - name: Build tuisttool
+        run: swiftc TuistTool.swift -o tuisttool
+
       - name: Download private xcconfig
         run: |
           echo "GITHUB_ACCESS_TOKEN=${{ secrets.CONFIG_PRIVATE_REPO_TOKEN }}" > .env
@@ -83,6 +88,11 @@ jobs:
 
       - name: Setup mise & tuist
         uses: jdx/mise-action@v2
+
+      # 커밋된 tuisttool 바이너리는 로컬 macOS 26 기준으로 빌드되어 macos-15 러너에서 로드 불가
+      # → 러너 OS에 맞게 소스에서 재컴파일 (Install dependencies·fastlane 의 ./tuisttool 호출 대비)
+      - name: Build tuisttool
+        run: swiftc TuistTool.swift -o tuisttool
 
       - name: Setup Ruby & fastlane
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
## 무엇을 / 왜

PR #107 머지 후 `TestFlight Deploy` 워크플로우의 `test` 잡이 `Generate project` 스텝에서 exit code 134로 실패했습니다.

**원인**: 레포에 커밋된 `tuisttool` 바이너리가 로컬 macOS 26.0 기준으로 빌드되어 있어, `macos-15` 러너에서 dyld 로드에 실패합니다.

\`\`\`
dyld: Library not loaded: /usr/lib/swift/libswift_DarwinFoundation2.dylib
  Referenced from: .../tuisttool (built for macOS 26.0 which is newer than running OS)
Abort trap: 6  ./tuisttool install
\`\`\`

## 변경 사항

- `test`·`deploy` 두 잡의 `Setup mise & tuist` 직후에 `swiftc TuistTool.swift -o tuisttool` 재컴파일 스텝 추가
- 러너 OS에 맞게 소스에서 다시 빌드하여 stale 바이너리를 덮어씀
- `test` 잡의 `Generate project`, `deploy` 잡의 `Install dependencies`, `fastlane/Fastfile`의 `./tuisttool generate` 세 사용처를 모두 커버

## To Reviewer

- `tuisttool`은 `TuistTool.swift`를 컴파일한 바이너리라 소스에서 그대로 재빌드해도 동작이 동일합니다. 로컬에서 단독 컴파일이 성공함을 확인했습니다.
- 근본적으로는 사전 빌드 바이너리를 커밋하지 않고 `.gitignore` 처리하거나 on-demand 컴파일 래퍼로 전환하면 좋겠습니다. 이번 PR에서는 CI 복구에 범위를 한정했습니다.
- 검증은 머지 후 `TestFlight Deploy` 실행 또는 `workflow_dispatch` 수동 실행으로 `test` 잡 통과를 확인하면 됩니다.