### PR TITLE
[FIX] CI 테스트 스킴 구성 및 Sendable 빌드 오류 수정

### DIFF
--- a/Projects/App/Project.swift
+++ b/Projects/App/Project.swift
@@ -29,8 +29,8 @@ let project = Project.makeAppModule(
   infoPlist: .appInfoPlist,
   entitlements: .file(path: "Bangawo.entitlements"),
   schemes: [
-    // 테스트 플랜 스킴: 커스텀 구성명 사용 (.debug / .prod 중 택1)
-    Scheme.makeTestPlanScheme(target: .debug, name: Project.Environment.appName),
+    // 테스트 타겟을 직접 지정하는 스킴 (.debug 구성)
+    Scheme.makeScheme(target: .debug, name: Project.Environment.appName),
 
   ]
 )

--- a/Projects/Presentation/HomeFeature/Sources/GroupDetail/GroupDetailFeature.swift
+++ b/Projects/Presentation/HomeFeature/Sources/GroupDetail/GroupDetailFeature.swift
@@ -122,6 +122,7 @@ public struct GroupDetailFeature {
                 }
 
             case .groupClosed(.success):
+                let dismiss = dismiss
                 return .run { _ in await dismiss() }
 
             case .groupClosed(.failure):


### PR DESCRIPTION
## 무엇을 / 왜

PR #108(tuisttool 재컴파일)로 `Generate project`까지는 통과했으나, `test` 잡의 `Run tests` 스텝에서 연달아 실패했습니다. 클린 빌드 기준으로 두 가지 문제를 확인해 수정합니다.

### 1. 스킴에 test 액션이 비어 있음 (exit 66)

```
xcodebuild: error: Scheme Bangawo is not currently configured for the test action.
```

- `Bangawo` 스킴이 존재하지 않는 `Tests/Sources/BangawoTestPlan.xctestplan`을 `.testPlans(...)`로 참조해, 생성된 스킴의 `<TestPlans>`·`<Testables>`가 모두 비어 있었습니다.
- 프로젝트에 이미 있는 `Scheme.makeScheme`(테스트 타겟을 `.targets(["BangawoTests"])`로 직접 지정)로 교체했습니다.

### 2. 클린 빌드에서 드러난 Sendable 오류 (증분 빌드에 가려져 있던 잠재 오류)

```
GroupDetailFeature.swift:125: error: capture of 'self' with non-Sendable type 'GroupDetailFeature' in a '@Sendable' closure
```

- `.run` 클로저에서 `@Dependency(\.dismiss)` 인스턴스 프로퍼티를 참조해 `self`를 캡처하고 있었습니다.
- 바로 위 `groupClient` 처리와 동일하게 `dismiss`를 로컬로 추출해 캡처를 제거했습니다.

## 검증

CI와 동일한 명령을 로컬에서 실행해 통과를 확인했습니다.

- `xcodebuild ... build` → `** BUILD SUCCEEDED **`
- `xcodebuild ... test` → `Executed 3 tests, with 0 failures` / `** TEST SUCCEEDED **`

## To Reviewer

- 2번 오류는 이번 브랜치가 만든 것이 아니라 기존 코드에 있던 잠재 오류가 클린 빌드에서 드러난 것입니다. 증분 빌드 캐시 때문에 그동안 커밋 게이트/CI에서 감지되지 않았습니다.
- `makeScheme`는 `BangawoTests`만 실행합니다. 추후 모듈별 테스트 타겟까지 게이트에 포함하려면 워크스페이스 단위 테스트 플랜 도입을 별도로 논의하면 좋겠습니다.