### PR TITLE
[CHORE] TestFlight Deploy에서 실효 없는 test 잡 제거

### DIFF
--- a/.github/workflows/testflight-deploy.yml
+++ b/.github/workflows/testflight-deploy.yml
@@ -12,55 +12,11 @@ concurrency:
 
 jobs:
   # ──────────────────────────────────────────────────────────
-  # 1. Test (배포 게이트)
-  # ──────────────────────────────────────────────────────────
-  test:
-    # PR 이 머지된 경우 또는 수동 실행일 때만 동작 (단순 close 는 스킵)
-    if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
-    runs-on: macos-15
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Select Xcode
-        uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: latest-stable
-
-      # .mise.toml(tuist 4.174.0)이 mise.toml(latest)보다 우선하므로 4.174.0 설치됨
-      - name: Setup mise & tuist
-        uses: jdx/mise-action@v2
-
-      # 커밋된 tuisttool 바이너리는 로컬 macOS 26 기준으로 빌드되어 macos-15 러너에서 로드 불가
-      # → 러너 OS에 맞게 소스에서 재컴파일
-      - name: Build tuisttool
-        run: swiftc TuistTool.swift -o tuisttool
-
-      - name: Download private xcconfig
-        run: |
-          echo "GITHUB_ACCESS_TOKEN=${{ secrets.CONFIG_PRIVATE_REPO_TOKEN }}" > .env
-          make download-privates
-
-      - name: Generate project
-        run: |
-          ./tuisttool install
-          ./tuisttool generate
-
-      - name: Run tests
-        run: |
-          set -eo pipefail
-          UDID=$(xcrun simctl list devices available --json \
-            | python3 -c "import json,sys; d=json.load(sys.stdin)['devices']; ids=[x['udid'] for r in d.values() for x in r if 'iPhone' in x['name']]; print(ids[0])")
-          xcodebuild test \
-            -workspace Bangawo.xcworkspace \
-            -scheme Bangawo \
-            -destination "id=$UDID" \
-            CODE_SIGNING_ALLOWED=NO
-
-  # ──────────────────────────────────────────────────────────
-  # 2. Deploy (TestFlight)
+  # Deploy (TestFlight)
   # ──────────────────────────────────────────────────────────
   deploy:
-    needs: test
+    # PR 이 머지된 경우 또는 수동 실행일 때만 동작 (단순 close 는 스킵)
+    if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
     runs-on: macos-15
     env:
       # Appfile / Fastfile


### PR DESCRIPTION
## 무엇을 / 왜

`TestFlight Deploy` 워크플로우의 `test` 잡을 제거합니다.

- 현재 존재하는 테스트는 **템플릿 테스트 3개뿐**(`testExample` 빈 함수, `testPerformanceExample` 빈 measure, `2+2==4`)이라 배포 게이트로서 실효가 없습니다.
- 반면 이 잡은 시뮬레이터 destination·스킴 설정 문제로 CI를 반복 실패시켜, PR 머지 후 배포가 계속 막혔습니다.
- 앱 빌드 검증은 `deploy` 잡의 fastlane 아카이브가 그대로 수행하므로, test 잡 없이도 컴파일 오류는 배포 단계에서 잡힙니다.

## 변경 사항

- `test` 잡 및 `deploy`의 `needs: test` 제거
- `deploy` 잡에 머지 조건 가드를 직접 추가
  - 기존에는 `test` 잡의 `if`가 "머지 또는 수동 실행"을 걸러주고 `deploy`가 이를 `needs`로 의존했음
  - test 잡을 없애면 단순 PR close(머지 아님)에도 deploy가 트리거되므로, 동일 조건 `if`를 deploy로 이전

```yaml
deploy:
  if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
  runs-on: macos-15
```

## To Reviewer

- 추후 실질적인 단위/통합 테스트가 마련되면 별도 CI(예: PR-open 트리거의 test 워크플로우)로 게이트를 다시 도입하는 것을 권장합니다.
- YAML 유효성 및 `deploy` 잡의 `if`/`needs` 구성은 로컬에서 확인했습니다.