### PR TITLE
[FIX] match 인증서 repo 클론 인증 토큰 누락 해결

### DIFF
--- a/.github/workflows/testflight-deploy.yml
+++ b/.github/workflows/testflight-deploy.yml
@@ -26,7 +26,8 @@ jobs:
       # match
       MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
       MATCH_KEYCHAIN_PASSWORD: ${{ secrets.MATCH_KEYCHAIN_PASSWORD }}
-      MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
+      # 인증서 repo(private) 클론용 토큰 — Deploy 스텝에서 MATCH_GIT_BASIC_AUTHORIZATION 로 인코딩
+      CONFIG_PRIVATE_REPO_TOKEN: ${{ secrets.CONFIG_PRIVATE_REPO_TOKEN }}
       # App Store Connect API (Fastfile 변수명)
       APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
       APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
@@ -58,7 +59,7 @@ jobs:
 
       - name: Download private xcconfig
         run: |
-          echo "GITHUB_ACCESS_TOKEN=${{ secrets.CONFIG_PRIVATE_REPO_TOKEN }}" > .env
+          echo "GITHUB_ACCESS_TOKEN=${CONFIG_PRIVATE_REPO_TOKEN}" > .env
           make download-privates
 
       # Matchfile 이 keychain_name("login") 을 고정 사용하므로 CI 에서 login 키체인을 준비
@@ -75,4 +76,8 @@ jobs:
         run: ./tuisttool install
 
       - name: Deploy to TestFlight
-        run: bundle exec fastlane beta
+        run: |
+          # match 가 private 인증서 repo 를 클론할 때 사용할 basic auth 헤더 생성
+          # (base64 는 긴 토큰에서 줄바꿈이 삽입되므로 제거)
+          export MATCH_GIT_BASIC_AUTHORIZATION=$(printf 'x-access-token:%s' "${CONFIG_PRIVATE_REPO_TOKEN}" | base64 | tr -d '\n')
+          bundle exec fastlane beta


### PR DESCRIPTION
## 변경 사항

TestFlight 배포 실패(fastlane `match` 스텝)를 해결합니다.

- 워크플로우가 참조하던 `MATCH_GIT_BASIC_AUTHORIZATION` 시크릿이 repo에 등록돼 있지 않아, private 인증서 repo(`Roy-wonji/FastlaneMatch`) 클론 시 인증 헤더가 비어 실패했습니다.
- 빈 시크릿 참조를 제거하고, 이미 등록된 `CONFIG_PRIVATE_REPO_TOKEN`을 base64 인코딩해 Deploy 스텝에서 `MATCH_GIT_BASIC_AUTHORIZATION`으로 주입하도록 변경했습니다.

## To Reviewer

- 이 방식은 `CONFIG_PRIVATE_REPO_TOKEN`이 classic PAT(`repo` 스코프)일 때 동작합니다. 그래야 다른 소유자의 private repo인 `Roy-wonji/FastlaneMatch`까지 접근됩니다.
- 만약 이 토큰이 fine-grained PAT로 특정 repo에만 스코프돼 있으면 클론이 또 실패하므로, 그 경우 전용 `MATCH_GIT_BASIC_AUTHORIZATION` 시크릿 추가로 전환이 필요합니다.
- 머지 후 workflow_dispatch로 수동 실행하면 match 스텝 통과 여부를 확인할 수 있습니다.