### PR TITLE
[FIX] TestFlight 배포 codesign 무한 대기 해결

### DIFF
--- a/.github/workflows/testflight-deploy.yml
+++ b/.github/workflows/testflight-deploy.yml
@@ -18,6 +18,9 @@ jobs:
     # PR 이 머지된 경우 또는 수동 실행일 때만 동작 (단순 close 는 스킵)
     if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
     runs-on: macos-15
+    # 서명 단계가 매달려도 러너를 오래 점유하지 않도록 상한을 둔다
+    # (concurrency 가 cancel-in-progress: false 라 멈춘 잡이 후속 배포를 전부 막는다)
+    timeout-minutes: 60
     env:
       # Appfile / Fastfile
       APP_IDENTIFIER: ${{ secrets.APP_IDENTIFIER }}
@@ -26,6 +29,9 @@ jobs:
       # match
       MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
       MATCH_KEYCHAIN_PASSWORD: ${{ secrets.MATCH_KEYCHAIN_PASSWORD }}
+      # 러너에 이미 있는 login 키체인은 비밀번호를 알 수 없어 match 의 set-key-partition-list 가 실패한다
+      # → 전용 키체인을 새로 만들어 쓴다 (Matchfile 이 이 값을 참조)
+      MATCH_KEYCHAIN_NAME: build.keychain
       # 인증서 repo(private) 클론용 토큰 — Deploy 스텝에서 MATCH_GIT_BASIC_AUTHORIZATION 로 인코딩
       CONFIG_PRIVATE_REPO_TOKEN: ${{ secrets.CONFIG_PRIVATE_REPO_TOKEN }}
       # App Store Connect API (Fastfile 변수명)
@@ -62,14 +68,16 @@ jobs:
           echo "GITHUB_ACCESS_TOKEN=${CONFIG_PRIVATE_REPO_TOKEN}" > .env
           make download-privates
 
-      # Matchfile 이 keychain_name("login") 을 고정 사용하므로 CI 에서 login 키체인을 준비
+      # 생성 실패를 무시하면 러너의 기존 키체인을 그대로 쓰게 되고, 비밀번호 불일치로
+      # codesign 이 뜰 수 없는 승인 팝업을 기다리며 무한 대기한다. 실패 시 즉시 잡을 멈춘다.
       - name: Prepare keychain
         run: |
-          security create-keychain -p "$MATCH_KEYCHAIN_PASSWORD" login.keychain-db || true
-          security set-keychain-settings -lut 21600 login.keychain-db
-          security unlock-keychain -p "$MATCH_KEYCHAIN_PASSWORD" login.keychain-db
-          security list-keychains -d user -s login.keychain-db
-          security default-keychain -s login.keychain-db
+          security create-keychain -p "$MATCH_KEYCHAIN_PASSWORD" build.keychain
+          security set-keychain-settings -lut 21600 build.keychain
+          security unlock-keychain -p "$MATCH_KEYCHAIN_PASSWORD" build.keychain
+          # xcodebuild 가 시스템 인증서를 찾을 수 있도록 login 키체인도 검색 목록에 남긴다
+          security list-keychains -d user -s build.keychain login.keychain-db
+          security default-keychain -s build.keychain
 
       # SPM 의존성 설치 (fastlane 의 ensure_workspace 가 generate 하기 전 선행)
       - name: Install dependencies

--- a/fastlane/Matchfile
+++ b/fastlane/Matchfile
@@ -6,7 +6,8 @@ include_all_certificates(true)
 shallow_clone(true)
 skip_certificate_matching(true)
 skip_confirmation(true)
-keychain_name("login")
+# 로컬은 login 키체인을 그대로 쓰고, CI 는 MATCH_KEYCHAIN_NAME 으로 전용 키체인을 지정한다
+keychain_name(ENV["MATCH_KEYCHAIN_NAME"] || "login")
 keychain_password(ENV["MATCH_KEYCHAIN_PASSWORD"])
 
 # .env 파일에서 API 키가 있으면 임시 JSON 파일 생성 후 사용 완료시 자동 삭제


### PR DESCRIPTION
## 변경 사항

TestFlight 배포가 `Deploy to TestFlight` 스텝에서 2시간 매달리던 문제를 해결합니다. ([문제 발생 run](https://github.com/DDD-Community/DDD-13-iOS2-iOS/actions/runs/29271339348))

원인은 세 단계로 이어졌습니다.

1. `Prepare keychain`이 `security create-keychain ... login.keychain-db || true`로 실행되는데, 러너에는 `login.keychain-db`가 이미 존재합니다. `A keychain with the same name already exists` 실패를 `|| true`가 삼켜서, 의도한 "`MATCH_KEYCHAIN_PASSWORD`로 잠긴 새 키체인"이 아니라 **러너 기본 비밀번호로 잠긴 기존 키체인**이 그대로 쓰였습니다.
2. 그 결과 match의 `set-key-partition-list`가 비밀번호 불일치로 실패했습니다. 이 설정이 codesign의 GUI 승인 팝업을 막아주는 장치인데, fastlane은 경고만 내고 진행하기 때문에 잡이 실패하지 않고 빌드까지 갔습니다.

   ```
   security: SecKeychainItemSetAccessWithPassword: The user name or passphrase you entered is not correct.
   Could not configure imported keychain item (certificate) to prevent UI permission popup when code signing
   ```
3. 빌드 중 codesign이 헤드리스 러너에서 뜰 수 없는 팝업을 기다리며 무한 대기했습니다. 취소 시점에 `codesign` 프로세스 3개가 orphan으로 남아 있었습니다.

변경 내용은 다음과 같습니다.

- 러너의 기존 `login` 키체인 대신 전용 `build.keychain`을 새로 만들어 사용합니다. `MATCH_KEYCHAIN_NAME` 환경변수로 주입하며, `Matchfile`은 이 값을 참조하되 없으면 기존처럼 `login`으로 폴백해 로컬 `match_development`는 영향받지 않습니다.
- 키체인 생성 실패를 삼키던 `|| true`를 제거했습니다. 이제 실패가 조용히 넘어가지 않고 잡이 그 자리에서 멈춥니다.
- `deploy` 잡에 `timeout-minutes: 60`을 추가했습니다.

## To Reviewer

- 머지 전 `workflow_dispatch`로 이 브랜치에서 실제 배포를 돌려 검증했습니다. ([검증 run](https://github.com/DDD-Community/DDD-13-iOS2-iOS/actions/runs/29381516324))
- `security list-keychains`에 `login.keychain-db`를 함께 남겨두었습니다. 검색 목록에서 빠지면 xcodebuild가 시스템 인증서를 찾지 못할 수 있기 때문입니다.
- `timeout-minutes`를 추가한 이유는 `concurrency` 그룹이 `cancel-in-progress: false`여서, 멈춘 잡 하나가 이후 배포를 전부 막기 때문입니다.
- 급한 배포는 로컬에서 `fastlane beta`로 먼저 처리해 **1.0.0 (build 2)**가 TestFlight에 올라가 있습니다. 로컬은 `login` 키체인 비밀번호가 일치해 같은 문제가 재현되지 않았고, 이는 이번 진단과도 일치합니다.