### PR TITLE
[CHORE] release 가격 설정을 App Store Connect 수동 관리로 전환

### DIFF
--- a/docs/app-store-release.md
+++ b/docs/app-store-release.md
@@ -97,6 +97,7 @@ GitHub Actions → `App Store Release` → `Run workflow` → 버전 입력. 이
 - 버전은 `v1.0.0` 형식만 허용한다. 태그명에서 `v` 를 뗀 값이 **제출할 TestFlight 빌드를 고르는 키**가 된다(버전을 코드에 주입하지 않으므로, 그 버전의 빌드가 TestFlight 에 미리 올라가 있어야 한다).
 - 이미 심사 대기 중인 빌드가 있으면 `reject_if_possible: true` 설정에 따라 기존 제출을 반려하고 새로 올린다.
 - 수출 규정·IDFA 답변은 `submission_information` 에 하드코딩돼 있다. 광고 SDK를 도입하면 `add_id_info_uses_idfa` 를 갱신해야 한다.
+- 가격·판매 지역·세금 카테고리는 App Store Connect에서 관리한다. `Fastfile`에 `price_tier`를 다시 추가하지 않는다.
 - 앱 이름(`ko/name.txt`)은 App Store 전체에서 고유해야 한다. 최초 등록명과 다르면 업로드가 거절된다.
 - 실패 시 `fastlane-logs-{버전}` 아티팩트에 `report.xml` 이 남는다(14일 보관).
 

--- a/docs/app-store-release.md
+++ b/docs/app-store-release.md
@@ -12,6 +12,34 @@ TestFlight 업로드(`beta`)와 별개로, App Store 심사 제출·출시까지
 >
 > App Store Connect 는 빌드의 마케팅 버전(`CFBundleShortVersionString`)과 같은 App Store 버전에만 그 빌드를 붙일 수 있고 빌드 버전은 빌드 시점에 고정된다. 따라서 **마케팅 버전은 RC 빌드를 만들기 전에 정해져야 한다.** 현재 마케팅 버전 소스는 `Plugins/ProjectTemplatePlugin/ProjectDescriptionHelpers/Project+Templete/Extension+String.swift` 의 `appVersion(version:)` 기본값(`1.0.0`)이므로, 다음 버전을 출시하려면 이 값을 올려 `tuist generate` 후 커밋하고 `beta` 로 RC 를 올린 뒤 같은 버전으로 release 한다.
 
+## 첫 배포 전 App Store Connect 설정
+
+아래 항목은 앱 버전 메타데이터와 별개인 계정·앱 단위 설정이거나 Fastlane에서 안정적으로 지원하지 않으므로, 첫 심사 제출 전에 App Store Connect에서 직접 완료한다.
+
+- **가격·판매 지역·세금 카테고리**: `Monetization > Pricing and Availability`에서 무료 가격, 기준 국가/지역, 판매 국가, 세금 카테고리를 확정한다. `price_tier` 자동화는 현재 App Store Connect API와 호환되지 않아 사용하지 않는다.
+- **앱 개인정보 보호**: 앱과 포함된 제3자 SDK(Kakao, Naver, Firebase 등)의 데이터 수집·연결·추적 여부를 모두 반영하고 답변을 게시한다.
+- **Privacy Manifest**: 배포 아카이브의 개인정보 보호 리포트를 확인하고, 앱 코드와 FirebaseCore·FirebaseMessaging 등 필수 대상 SDK의 `PrivacyInfo.xcprivacy` 및 서명이 포함됐는지 검증한다.
+- **콘텐츠 권리**: 지도·장소 검색·프로필 이미지 등 제3자 콘텐츠를 표시할 권리가 있는지 답변한다.
+- **EU 디지털 서비스법(DSA)**: EU 판매 여부와 관계없이 trader 여부를 선언하고, trader라면 연락처 인증을 완료한다.
+- **계약·규정 준수**: 최신 Apple Developer Program 계약과 보류 중인 compliance review가 없는지 확인한다. 유료 앱이나 인앱 결제가 있으면 Paid Apps Agreement와 세금·은행 정보도 완료한다.
+- **심사용 계정·백엔드**: 모든 기능을 확인할 수 있는 활성 데모 계정 또는 완전한 데모 모드를 준비하고, 심사 기간 동안 운영 서버와 외부 로그인 설정을 유지한다.
+- **계정 삭제**: 앱에서 계정을 생성한다면 앱 내부에서 계정과 관련 데이터를 삭제할 수 있어야 한다. Apple 로그인을 사용한 계정은 삭제 시 토큰도 해지한다.
+- **공개 URL**: 개인정보 처리방침과 고객지원 URL이 로그인 없이 열리고 실제 내용을 제공하는지 확인한다.
+- **수출 규정·IDFA**: 앱 동작이 `ITSAppUsesNonExemptEncryption=false`, `export_compliance_uses_encryption=false`, `add_id_info_uses_idfa=false` 답변과 일치하는지 확인한다.
+
+현재 Fastlane `release` lane이 자동화하는 범위는 다음과 같다.
+
+| 자동 설정·처리 | 수동 확인 |
+| --- | --- |
+| TestFlight 최신 빌드 선택 | 가격·판매 지역·세금 카테고리 |
+| 앱 버전 메타데이터·카테고리 업로드 | 앱 개인정보 보호 답변 게시 |
+| 스크린샷 동기화 | 콘텐츠 권리·DSA·계약 상태 |
+| 연령 등급 질문지 업로드 | 데모 계정·계정 삭제·백엔드 접근성 |
+| 심사 연락처·심사 노트 업로드 | 개인정보 처리방침·지원 URL 실제 접근 |
+| 수출 규정·IDFA 답변 및 심사 제출 | Fastlane 답변과 실제 SDK 동작의 일치 |
+
+> 최초 버전은 App Store Connect가 `release_notes`를 사용하지 않으므로 Fastlane이 업로드를 건너뛴다. 두 번째 버전부터 `fastlane/metadata/ko/release_notes.txt`가 반영된다.
+
 ## 배포 절차
 
 ### 1. 메타데이터 갱신

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -161,9 +161,8 @@ platform :ios do
       skip_binary_upload:             true,
       skip_metadata:                  false,
       metadata_path:                  METADATA_DIR,
-      # 첫 제출 + 무료(0 티어)면 deliver 가 전 국가 이용 가능까지 자동 활성화한다
-      # (레거시 가격 API 라 실패할 수 있으며, 그 경우 ASC 에서 가격을 수동 설정한다)
-      price_tier:                     0,
+      # 가격·판매 지역·세금 카테고리는 첫 제출 전에 App Store Connect 에서 직접 설정한다.
+      # deliver 의 price_tier 는 제거된 레거시 API 필드를 사용해 첫 가격 설정 시 실패할 수 있다.
       # 연령 등급 질문지는 첫 제출 시 미설정이면 심사 제출이 막히므로 API 로 자동 채운다
       app_rating_config_path:         RATING_CONFIG,
       skip_screenshots:               false,


### PR DESCRIPTION
## 변경 사항
`deliver` 의 `price_tier` 는 제거된 레거시 가격 API 를 사용해 첫 가격 설정 시 실패할 수 있어, 가격·판매 지역·세금 카테고리를 App Store Connect 에서 직접 관리하도록 전환했습니다.

- `Fastfile`: `release` lane 에서 `price_tier: 0` 제거 및 사유 주석 정리
- `docs/app-store-release.md`: 주의사항에 `price_tier` 재추가 금지 명시
- `docs/app-store-release.md`: `첫 배포 전 App Store Connect 설정` 섹션 추가 — 가격·앱 개인정보 보호·Privacy Manifest·콘텐츠 권리·DSA·계약·데모 계정·계정 삭제·공개 URL·수출 규정 항목 정리
- `docs/app-store-release.md`: Fastlane `release` lane 자동화 범위와 수동 확인 항목을 표로 구분

## To Reviewer
가격 설정은 이제 자동화 대상이 아니므로, 첫 심사 제출 전에 App Store Connect `Monetization > Pricing and Availability` 에서 무료 가격과 판매 지역, 세금 카테고리를 미리 확정해 두셔야 합니다.

새로 추가한 표는 자동으로 처리되는 항목과 사람이 확인해야 하는 항목의 경계를 정리한 것이니, 실제 운영 기준과 다른 부분이 있으면 알려주시면 반영하겠습니다.