### PR TITLE
[CHORE] PR 검증 워크플로 추가 및 TestFlight 배포 분기

### DIFF
--- a/.github/scripts/has-app-changes.sh
+++ b/.github/scripts/has-app-changes.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# 변경 파일 목록을 stdin 으로 받아 앱 바이너리에 영향을 주는 변경이 있는지 판정한다.
+#   exit 0 — 영향 있음 (빌드·배포 필요)
+#   exit 1 — 전부 문서·설정 (스킵 가능)
+#
+# pr-validate.yml 과 testflight-deploy.yml 이 같은 기준을 써야 하므로 여기 한 곳에 둔다.
+#
+# 사용 예:
+#   gh pr view "$PR_NUMBER" --json files --jq '.files[].path' | .github/scripts/has-app-changes.sh
+set -euo pipefail
+
+# denylist 인 이유: allowlist 는 새 소스 경로가 빠졌을 때 빌드가 조용히 스킵되는 실패로
+# 가지만, denylist 는 불필요한 빌드가 한 번 도는 복구 가능한 실패로 떨어진다.
+#
+# 여기 넣지 않은 것들 —
+#   .mise.toml         Tuist 버전을 고정하므로 빌드 결과에 영향을 준다
+#   .github/workflows/ 배포 로직 자체라 검증 없이 넘길 수 없다
+#   .claude/, CLAUDE.md .gitignore 에서 이미 무시되어 PR 파일 목록에 나타나지 않는다
+IGNORE_PATTERNS='\.md$
+^docs/
+^\.github/ISSUE_TEMPLATE/
+^\.github/scripts/
+^\.gitignore$
+^\.editorconfig$'
+
+files=$(cat)
+
+# 목록을 받지 못했으면 판정할 근거가 없으므로 안전한 쪽(영향 있음)으로 떨어뜨린다
+if [ -z "$files" ]; then
+    exit 0
+fi
+
+printf '%s\n' "$files" \
+    | grep -Evf <(printf '%s\n' "$IGNORE_PATTERNS") \
+    | grep -q .

--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -1,0 +1,150 @@
+name: PR Validate
+
+# 통합 브랜치(develop · main)로 들어가는 PR 을 머지 전에 컴파일·테스트로 검증한다.
+#   develop — 1차 방어선. 실제 코드 통합이 여기서 일어난다.
+#   main    — 2차 방어선. develop→main 사이에 쌓인 PR 조합에서만 나는 문제를 잡는다.
+on:
+  pull_request:
+    branches: [develop, main]
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+# 같은 PR 에 새 커밋이 오면 이전 실행은 의미가 없다 (배포와 달리 취소해도 부작용이 없다)
+concurrency:
+  group: pr-validate-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  # ──────────────────────────────────────────────────────────
+  # Check (빌드가 필요한 변경인지 판정)
+  # ──────────────────────────────────────────────────────────
+  check:
+    runs-on: ubuntu-latest
+    outputs:
+      should_build: ${{ steps.decide.outputs.should_build }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Decide whether to build
+        id: decide
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          emit() {
+            echo "should_build=$1" >> "$GITHUB_OUTPUT"
+            echo "$2" >> "$GITHUB_STEP_SUMMARY"
+            echo "$2"
+            exit 0
+          }
+
+          # 파일 목록 조회가 실패하면 판정 근거가 없으므로 안전한 쪽(빌드)으로 떨어뜨린다
+          files=$(gh pr view "$PR_NUMBER" --json files --jq '.files[].path' || true)
+          if [ -z "$files" ]; then
+            emit true "✅ 변경 파일 목록을 확인하지 못해 검증을 진행합니다."
+          fi
+
+          if printf '%s\n' "$files" | .github/scripts/has-app-changes.sh; then
+            emit true "✅ 앱에 영향을 주는 변경이 있어 빌드·테스트를 진행합니다."
+          else
+            emit false "⏭️ 문서·설정 파일만 변경되어 빌드·테스트를 건너뜁니다."
+          fi
+
+  # ──────────────────────────────────────────────────────────
+  # Validate (빌드 + 테스트)
+  # ──────────────────────────────────────────────────────────
+  validate:
+    needs: check
+    if: needs.check.outputs.should_build == 'true'
+    runs-on: macos-15
+    timeout-minutes: 45
+    env:
+      # 비공개 xcconfig(API 키) 를 내려받기 위한 토큰
+      CONFIG_PRIVATE_REPO_TOKEN: ${{ secrets.CONFIG_PRIVATE_REPO_TOKEN }}
+      DERIVED_DATA: .build-ci
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Select Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
+      - name: Setup mise & tuist
+        uses: jdx/mise-action@v2
+
+      # 커밋된 tuisttool 바이너리는 로컬 macOS 26 기준으로 빌드되어 macos-15 러너에서 로드 불가
+      # → 러너 OS에 맞게 소스에서 재컴파일
+      - name: Build tuisttool
+        run: swiftc TuistTool.swift -o tuisttool
+
+      - name: Download private xcconfig
+        run: |
+          echo "GITHUB_ACCESS_TOKEN=${CONFIG_PRIVATE_REPO_TOKEN}" > .env
+          make download-privates
+
+      # fastlane 의 ensure_workspace 를 거치지 않으므로 install·generate 를 직접 호출한다
+      - name: Generate Xcode project
+        run: |
+          ./tuisttool install
+          ./tuisttool generate
+
+      # 배포 타겟이 iOS 26.0 이라 하위 런타임 시뮬레이터로는 테스트가 뜨지 않는다.
+      # 러너 이미지마다 제공 런타임이 달라, 이름을 고정하지 않고 실행 시점에 고른다.
+      - name: Resolve simulator
+        id: sim
+        run: |
+          set -euo pipefail
+          cat > /tmp/resolve-simulator.py <<'PY'
+          import json, sys
+
+          devices = json.load(sys.stdin)["devices"]
+          candidates = []
+
+          for runtime, devs in devices.items():
+              if "SimRuntime.iOS-" not in runtime:
+                  continue
+              version = tuple(int(p) for p in runtime.split("SimRuntime.iOS-")[1].split("-"))
+              if version < (26,):
+                  continue
+              for dev in devs:
+                  if dev.get("isAvailable") and dev["name"].startswith("iPhone"):
+                      candidates.append((version, dev["udid"], dev["name"]))
+
+          if candidates:
+              version, udid, name = max(candidates)
+              sys.stderr.write("선택된 시뮬레이터: %s (iOS %s)\n" % (name, ".".join(map(str, version))))
+              print(udid)
+          PY
+
+          UDID=$(xcrun simctl list devices available -j | python3 /tmp/resolve-simulator.py)
+
+          if [ -z "$UDID" ]; then
+            echo "::error::iOS 26 이상 iPhone 시뮬레이터를 찾지 못했습니다."
+            xcrun simctl list runtimes
+            exit 1
+          fi
+
+          echo "udid=$UDID" >> "$GITHUB_OUTPUT"
+
+      - name: Build for testing
+        run: |
+          xcodebuild build-for-testing \
+            -workspace Bangawo.xcworkspace \
+            -scheme Bangawo \
+            -destination "id=${{ steps.sim.outputs.udid }}" \
+            -derivedDataPath "$DERIVED_DATA" \
+            CODE_SIGNING_ALLOWED=NO
+
+      - name: Test
+        run: |
+          xcodebuild test-without-building \
+            -workspace Bangawo.xcworkspace \
+            -scheme Bangawo \
+            -destination "id=${{ steps.sim.outputs.udid }}" \
+            -derivedDataPath "$DERIVED_DATA"

--- a/.github/workflows/testflight-deploy.yml
+++ b/.github/workflows/testflight-deploy.yml
@@ -6,18 +6,74 @@ on:
     types: [closed]
   workflow_dispatch:
 
-concurrency:
-  group: testflight-deploy
-  cancel-in-progress: false
+permissions:
+  contents: read
+  pull-requests: read
 
 jobs:
+  # ──────────────────────────────────────────────────────────
+  # Check (배포가 필요한 변경인지 판정)
+  # ──────────────────────────────────────────────────────────
+  check:
+    runs-on: ubuntu-latest
+    outputs:
+      should_deploy: ${{ steps.decide.outputs.should_deploy }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Decide whether to deploy
+        id: decide
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          MERGED: ${{ github.event.pull_request.merged }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+        run: |
+          set -euo pipefail
+
+          emit() {
+            echo "should_deploy=$1" >> "$GITHUB_OUTPUT"
+            echo "$2" >> "$GITHUB_STEP_SUMMARY"
+            echo "$2"
+            exit 0
+          }
+
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            emit true "✅ 수동 실행 — TestFlight 배포를 진행합니다."
+          fi
+
+          if [ "$MERGED" != "true" ]; then
+            emit false "⏭️ 머지되지 않고 닫힌 PR 이라 배포를 건너뜁니다."
+          fi
+
+          if echo "$LABELS" | jq -e 'index("skip-testflight")' >/dev/null; then
+            emit false "⏭️ \`skip-testflight\` 라벨이 붙어 있어 배포를 건너뜁니다."
+          fi
+
+          # 파일 목록 조회가 실패하면 판정 근거가 없으므로 안전한 쪽(배포)으로 떨어뜨린다
+          files=$(gh pr view "$PR_NUMBER" --json files --jq '.files[].path' || true)
+          if [ -z "$files" ]; then
+            emit true "✅ 변경 파일 목록을 확인하지 못해 배포를 진행합니다."
+          fi
+
+          if printf '%s\n' "$files" | .github/scripts/has-app-changes.sh; then
+            emit true "✅ 앱에 영향을 주는 변경이 있어 배포를 진행합니다."
+          else
+            emit false "⏭️ 문서·설정 파일만 변경되어 배포를 건너뜁니다."
+          fi
+
   # ──────────────────────────────────────────────────────────
   # Deploy (TestFlight)
   # ──────────────────────────────────────────────────────────
   deploy:
-    # PR 이 머지된 경우 또는 수동 실행일 때만 동작 (단순 close 는 스킵)
-    if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
+    needs: check
+    if: needs.check.outputs.should_deploy == 'true'
     runs-on: macos-15
+    # 실제 배포끼리만 직렬화한다 (판정 job 까지 배포 큐 뒤에 세우지 않도록 job 레벨에 둔다)
+    concurrency:
+      group: testflight-deploy
+      cancel-in-progress: false
     # 서명 단계가 매달려도 러너를 오래 점유하지 않도록 상한을 둔다
     # (concurrency 가 cancel-in-progress: false 라 멈춘 잡이 후속 배포를 전부 막는다)
     timeout-minutes: 60

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,6 +132,9 @@ prefix: `ic`(아이콘) / `sym`(로고·브랜드) / `img`(일반 이미지) / `
 예: `ic_arrow_right_24`, `sym_kakao`, `img_onboarding_01`
 Tuist가 camelCase로 변환하므로 코드에서는 `Image.Asset.icArrowRight24` 형태로 접근한다.
 
+## Handoff Protocol
+세션 시작 시 `.handoff/CURRENT.md` 가 있으면 미완료 인수인계다. 먼저 읽고 목표·진행 상태·제약을 복원한 뒤 "다음 액션"부터 이어서 진행하라. 작업을 마치거나 중단할 때는 이 파일을 최신화하라(없으면 `.handoff/README.md` 참고). 노트는 코드·git으로 복원 가능한 내용은 경로/커맨드로만 참조하는 경량 문서다.
+
 ## Git Rules
 
 ### Branch

--- a/README.md
+++ b/README.md
@@ -212,15 +212,32 @@ HEADER 목록과 상세 규칙은 [커밋 컨벤션](docs/commit-convention.md) 
 - 스킴은 코드 커버리지가 켜진 상태로 생성된다(`Scheme.makeScheme`).
 - **테스트는 시뮬레이터에서 실행한다.** `BangawoTests` 번들 ID에 대응하는 match 프로파일이 없어 디바이스 대상 실행은 사이닝에서 실패한다.
 - 현재 테스트 프레임워크는 XCTest다.
+- `develop` · `main` 대상 PR에서는 CI가 빌드와 테스트를 자동 실행한다(`pr-validate.yml`). 로컬에서 깨진 채로 PR을 올리면 머지 전에 걸린다.
 
 ### CI/CD
 
 | 워크플로 | 트리거 | 동작 |
 | --- | --- | --- |
 | `gemini-code-review.yml` | `develop` 대상 PR | 자동 코드 리뷰 코멘트 |
+| `pr-validate.yml` | `develop` · `main` 대상 PR | 빌드 + 테스트 (머지 전 검증) |
 | `testflight-deploy.yml` | `main` PR 머지 · 수동 | TestFlight 업로드 |
 | `release-tag.yml` | 수동(버전 입력) | 릴리즈 노트 생성 + `v*.*.*` 태그 |
 | `appstore-release.yml` | `v*.*.*` 태그 push · 수동 | 메타데이터 업로드 + 심사 제출 |
+
+`develop` 이 1차 방어선, `main` 이 2차 방어선이다. `main` 대상 검증은 `develop` → `main` 사이에 쌓인 여러 PR의 조합에서만 나는 문제를 잡는다.
+
+#### 빌드 · 배포가 스킵되는 변경
+
+`pr-validate` 와 `testflight-deploy` 는 변경 파일이 **전부** 아래에 해당하면 빌드를 건너뛴다. 판정 기준은 `.github/scripts/has-app-changes.sh` 한 곳에 있다.
+
+```
+*.md   ·   docs/**   ·   .github/ISSUE_TEMPLATE/**
+.github/scripts/**   ·   .gitignore   ·   .editorconfig
+```
+
+`.mise.toml`(Tuist 버전 고정)과 `.github/workflows/**`(배포 로직 자체)는 의도적으로 제외 목록에 없다. 스킵 여부와 사유는 Actions 실행 요약에 남는다.
+
+TestFlight 배포만 따로 건너뛰려면 PR에 `skip-testflight` 라벨을 붙인다.
 
 App Store 메타데이터(앱 이름 · 설명 · 키워드 · 스크린샷)의 원본은 `fastlane/metadata/` 다.
 App Store Connect 웹에서 수정하지 말고 이 파일들을 고쳐 커밋한다. 배포 시 덮어쓰기된다.

--- a/docs/app-store-release.md
+++ b/docs/app-store-release.md
@@ -86,6 +86,16 @@ bundle exec fastlane verify_metadata
 
 필수 파일 누락, `TODO_` 자리표시자, 글자 수 초과, 스크린샷 부재, 심사 연락처 환경변수 누락을 잡는다. 빌드는 30분 이상 걸리므로 반드시 먼저 통과시킨다.
 
+**함께 확인할 것 — 출시할 버전의 RC 빌드가 TestFlight 에 있는가.**
+
+`release` lane 은 새로 아카이브하지 않고 그 버전의 TestFlight 빌드를 골라 제출한다. 빌드가 없으면 태그를 만든 뒤 `App Store Release` 가 실패하고, 태그를 지우고 다시 만들어야 한다.
+
+TestFlight 배포는 `main` 머지마다 자동으로 돌지만 **문서·설정만 바뀐 머지에서는 건너뛴다**(아래 "주의 사항" 참고). 마지막 머지가 문서였다면 그 버전의 RC 가 없을 수 있으므로, App Store Connect 에서 확인하고 없으면 배포 전에 한 번 올린다.
+
+```
+GitHub Actions → TestFlight Deploy → Run workflow
+```
+
 ### 3. 배포 실행
 
 **Release Tag 워크플로(권장)**
@@ -123,6 +133,7 @@ GitHub Actions → `App Store Release` → `Run workflow` → 버전 입력. 이
 ## 주의 사항
 
 - 버전은 `v1.0.0` 형식만 허용한다. 태그명에서 `v` 를 뗀 값이 **제출할 TestFlight 빌드를 고르는 키**가 된다(버전을 코드에 주입하지 않으므로, 그 버전의 빌드가 TestFlight 에 미리 올라가 있어야 한다).
+- **`main` 머지가 항상 TestFlight 배포를 트리거하지는 않는다.** 변경 파일이 전부 문서·설정(`*.md`, `docs/**`, `.github/ISSUE_TEMPLATE/**`, `.github/scripts/**`, `.gitignore`, `.editorconfig`)이면 건너뛴다. 판정 기준은 `.github/scripts/has-app-changes.sh` 한 곳에 있고, 스킵 여부와 사유는 Actions 실행 요약에 남는다. 코드 변경이 있는데도 배포를 막고 싶으면 PR에 `skip-testflight` 라벨을 붙인다.
 - 이미 심사 대기 중인 빌드가 있으면 `reject_if_possible: true` 설정에 따라 기존 제출을 반려하고 새로 올린다.
 - 수출 규정·IDFA 답변은 `submission_information` 에 하드코딩돼 있다. 광고 SDK를 도입하면 `add_id_info_uses_idfa` 를 갱신해야 한다.
 - 가격·판매 지역·세금 카테고리는 App Store Connect에서 관리한다. `Fastfile`에 `price_tier`를 다시 추가하지 않는다.


### PR DESCRIPTION
## 작업 내용

- `develop`·`main` 대상 PR에서 앱 변경 여부를 판정하고 빌드·테스트하는 검증 워크플로를 추가했습니다.
- `main` 머지 시 문서·설정만 변경된 경우 TestFlight 배포를 건너뛰도록 변경 범위 판정을 통합했습니다.
- CI 구성과 배포 스킵 규칙을 README 및 배포 문서에 반영했습니다.
- AI 작업 인수인계 프로토콜을 `AGENTS.md`에 명문화했습니다.

## 검증

- 변경 범위 판정 스크립트 7개 케이스 통과
- TestFlight 배포 6개 분기 검증 통과
- PR 검증 3개 분기 및 시뮬레이터 해석 단계 로컬 실행 통과
- 워크플로 YAML 파싱 및 셸 문법 검사 통과

## 확인 사항

- 이 PR의 `PR Validate` 체크로 macOS GitHub Actions 러너에서 빌드·테스트가 실제 통과하는지 확인합니다.